### PR TITLE
Release from the package.json version on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
+# main only receives releases; the work happens on dev and the branches off it.
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 # Cancel an in-flight run when the same branch is pushed again.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,15 @@
 name: Release
 
-# Push a tag to get installers people can download:
-#
-#   git tag v0.1.0 && git push origin v0.1.0
-#
-# The release is created as a draft, so nothing becomes public until you say so.
-# Running this by hand from the Actions tab instead builds the same installers
-# and leaves them as workflow artifacts, which is the way to try a build without
-# announcing one.
+# Releases follow the version in package.json. Land a commit on main whose
+# version differs from the commit before it and this builds the installers and
+# opens a draft release for that version, so nothing becomes public until you
+# publish it. Running this by hand from the Actions tab instead builds the same
+# installers and leaves them as workflow artifacts, which is the way to try a
+# build without announcing one.
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
+    paths: [package.json]
   workflow_dispatch:
 
 concurrency:
@@ -18,8 +17,56 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      bumped: ${{ steps.check.outputs.bumped }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          # One commit back, to compare package.json against.
+          fetch-depth: 2
+
+      # package.json declares the release, but the installer filenames come from
+      # tauri.conf.json and the crate from Cargo.toml. Left unchecked, a bump in
+      # one of them ships v0.2.0 with 0.1.2 written on the installer.
+      - name: Read the version
+        id: check
+        shell: bash
+        run: |
+          version=$(jq -r .version package.json)
+          app=$(jq -r .version src-tauri/tauri.conf.json)
+          crate=$(grep -m1 '^version = ' src-tauri/Cargo.toml | cut -d'"' -f2)
+          if [ "$version" != "$app" ] || [ "$version" != "$crate" ]; then
+            echo "::error::versions differ: package.json $version, tauri.conf.json $app, Cargo.toml $crate"
+            exit 1
+          fi
+
+          previous=""
+          if git rev-parse -q --verify HEAD^ >/dev/null; then
+            previous=$(git show HEAD^:package.json | jq -r .version)
+          fi
+
+          bumped=false
+          if [ "${{ github.event_name }}" = push ] && [ "$version" != "$previous" ]; then
+            bumped=true
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "bumped=$bumped" >> "$GITHUB_OUTPUT"
+          echo "Version $version, was ${previous:-none}. Release: $bumped." >> "$GITHUB_STEP_SUMMARY"
+
   windows:
     name: Windows installer
+    needs: version
+    # A push that touches package.json without changing the version — a script,
+    # a dependency — is not a release.
+    if: needs.version.outputs.bumped == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     timeout-minutes: 60
 
@@ -56,7 +103,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+          # Empty for a manual run: build the installers, create nothing.
+          tagName: ${{ needs.version.outputs.bumped == 'true' && format('v{0}', needs.version.outputs.version) || '' }}
           releaseName: Desktop ComfyUI Server __VERSION__
           releaseDraft: true
           prerelease: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Work starts from an issue. Issue, commit and pull request titles are written in
+English.
+
+## Branches
+
+`main` holds what has been released. Everything else happens on `dev`.
+
+1. Open an issue describing the change.
+2. Branch off `dev`, named `<type>/<issue>-<short-name>` — `feat/12-tray-menu`,
+   `fix/13-stop-dialog`, `chore/14-release-flow`, `docs/15-readme`.
+3. Open a pull request into `dev` and name the issue in it — `Closes #12`.
+4. When `dev` is ready to ship, merge it into `main`. That is a release.
+
+## Commits
+
+[Conventional Commits](https://www.conventionalcommits.org), with a scope where
+one helps: `feat(tray): keep running after the window closes`. One line, and
+within 72 characters — GitHub cuts off longer subjects.
+
+`lefthook` runs oxlint and oxfmt over staged files on commit. CI repeats them
+along with `tsc --noEmit`, and compiles the Rust shell with clippy.
+
+## Releasing
+
+A release is the version in `package.json`. Bump it together with
+`src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` — the release workflow
+stops if the three disagree, since the installer filenames come from Tauri's
+copy — and merge that into `main`.
+
+GitHub Actions then builds the Windows installers and opens a **draft** release
+tagged `v<version>`; publish it when you are ready. Nothing is released by
+pushing a tag by hand any more.
+
+To try a build without announcing one, run the Release workflow from the Actions
+tab. It builds the same installers and leaves them as workflow artifacts.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ is inside. What you can check instead:
 - Everything the app runs is in this repository. There is no separate download
   and no telemetry — it only talks to your ComfyUI and to job servers you add
   yourself.
-- The installers are built by GitHub Actions from the tagged commit, not
+- The installers are built by GitHub Actions from the released commit, not
   uploaded from anyone's machine. The build log for each release is public.
 - It contains exactly two programs: `desktop-comfyui-server.exe`, the window,
   and `comfyui-server.exe`, the server from `src/`. The size is the Bun runtime
@@ -312,12 +312,10 @@ The server is bundled by `bun build --compile`, which carries the Bun runtime,
 so the sidecar is about 100 MB before compression.
 
 Installers are built by
-[`.github/workflows/release.yml`](.github/workflows/release.yml). Push a tag and
-they appear on a draft release:
-
-```bash
-git tag v0.1.0 && git push origin v0.1.0
-```
+[`.github/workflows/release.yml`](.github/workflows/release.yml). A release is
+the version in `package.json`: bump it — along with `src-tauri/tauri.conf.json`
+and `src-tauri/Cargo.toml`, which have to agree — and when that lands on `main`
+the installers appear on a draft release tagged `v<version>`.
 
 To try a build without announcing one, run the workflow by hand from the Actions
 tab; the installers come back as workflow artifacts instead.
@@ -329,6 +327,10 @@ bun run dev           # reload on change
 bun run check         # oxlint + oxfmt
 bun run check-types   # tsc --noEmit
 ```
+
+Work starts from an issue and lands on `dev`; `main` holds what has been
+released. [`CONTRIBUTING.md`](CONTRIBUTING.md) has the branch, commit and
+release steps.
 
 `src/` is the server and the UI, `src-tauri/` is the desktop shell. The two talk
 over HTTP like any other client, so the shell holds no state of its own — it


### PR DESCRIPTION
Closes #1.

A release is now the version in `package.json`. When a commit lands on `main`
whose version differs from the commit before it, the Release workflow builds the
Windows installers and opens a draft release tagged `v<version>`. Pushing a
`v*` tag by hand no longer releases anything.

- `release.yml`: a `version` job reads `package.json`, compares it with the
  previous commit, and stops the run if `package.json`,
  `src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` disagree — the
  installer filenames come from Tauri's copy, so a mismatch would ship v0.2.0
  named 0.1.2. The build job only runs on a bump, or on a manual run, where it
  still creates nothing and leaves the installers as artifacts.
- `ci.yml`: runs on `dev` as well as `main`.
- `CONTRIBUTING.md`: issue-driven work, branches off `dev` named
  `<type>/<issue>-<short-name>`, English titles, and the release steps. The
  README points at it and no longer documents the tag flow.

Not merged — the first release under this flow happens when `dev` reaches
`main` with a bumped version.
