### PR TITLE
feat(accept): hold off for a while, or accept on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
 
 # main only receives releases; the work happens on dev and the branches off it.
+# Pull requests are deliberately not filtered: a stacked pull request targets
+# the branch below it in the stack, and those names cannot be listed here.
 on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main, dev]
 
 # Cancel an in-flight run when the same branch is pushed again.
 concurrency:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,26 @@ answering claims nothing from a job server either, whatever its state says.
 
 The same three are in the tray, so it can be changed with the window closed.
 
+### When it accepts
+
+*Accepting* does not have to mean right now. Under *Accepting jobs* on the
+Settings page:
+
+- **Hold off for** 15, 30 or 60 minutes. The machine stops taking jobs and
+  starts again on its own, which is what you want when the GPU is yours for the
+  next half hour and remembering to switch back is the hard part.
+- **Every day, only between two times.** 02:00 to 08:00 lends the GPU out
+  overnight. An end before the start crosses midnight, so that window is tonight
+  until tomorrow morning rather than an error.
+
+Both only hold jobs back. ComfyUI stays up, runs you start here still go, and
+job servers still see the machine — they simply get nothing out of it until the
+hold is over. The header says which of the two is holding it and the status bar
+says how much is left.
+
+A hold is stored with its end time rather than counted down in memory, so
+restarting the app in the middle of one does not start claiming early.
+
 ## The tray
 
 Closing the window does not stop anything. The app stays in the tray with:

--- a/src/accepting.ts
+++ b/src/accepting.ts
@@ -1,0 +1,98 @@
+/**
+ * When this machine takes work from a job server.
+ *
+ * The run mode is a decision someone made, so nothing here changes it. A
+ * schedule or a pause is a gate in front of claiming instead: the mode still
+ * says "accepting", and this says whether right now counts. Keeping the two
+ * apart is what lets the tray go on showing what was chosen while the machine
+ * quietly stops and starts claiming on its own.
+ *
+ * Local runs and ComfyUI itself are untouched by any of it. The point is to
+ * lend the GPU out on a timetable, not to stop being able to use it.
+ */
+
+import type { AcceptSchedule, Settings } from "./settings";
+
+/** The furthest ahead a pause may be set, so a slip cannot lend nothing for a week. */
+export const MAX_PAUSE_MINUTES = 24 * 60;
+
+const MINUTE_MS = 60_000;
+
+/** Why nothing is being claimed, or `null` when it is. */
+export type AcceptBlock =
+  /** The mode is not `accepting`. */
+  | "mode"
+  /** Paused for a while, and the while is not up. */
+  | "paused"
+  /** Outside the daily window. */
+  | "schedule";
+
+export type AcceptState = {
+  accepting: boolean;
+  blockedBy: AcceptBlock | null;
+  /** When the pause runs out, or `null` when not paused. */
+  pausedUntil: number | null;
+  schedule: AcceptSchedule;
+};
+
+/** True for a `HH:MM` a day actually contains. */
+export function isTimeOfDay(value: unknown): value is string {
+  return typeof value === "string" && minutesOfDay(value) !== null;
+}
+
+/** `HH:MM` as minutes since midnight, or `null` when it is not one. */
+function minutesOfDay(time: string): number | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}
+
+/**
+ * Whether `now` falls inside the daily window, in this machine's own time zone
+ * — the window is written by whoever sits at it.
+ *
+ * A window whose end is before its start crosses midnight, which is the usual
+ * shape of "while I am asleep", so it is read that way rather than refused. Two
+ * equal ends would describe an empty day; the only useful reading is all of it.
+ */
+export function withinSchedule(schedule: AcceptSchedule, now: Date): boolean {
+  if (!schedule.enabled) return true;
+
+  const from = minutesOfDay(schedule.from);
+  const to = minutesOfDay(schedule.to);
+  // A window that cannot be read is not a reason to stop working.
+  if (from === null || to === null || from === to) return true;
+
+  const current = now.getHours() * 60 + now.getMinutes();
+  return from < to ? current >= from && current < to : current >= from || current < to;
+}
+
+/** What the agent, the API and the header all read to decide the same thing. */
+export function acceptState(settings: Settings, now = Date.now()): AcceptState {
+  const pausedUntil =
+    settings.pauseUntil !== null && settings.pauseUntil > now ? settings.pauseUntil : null;
+
+  const blockedBy: AcceptBlock | null =
+    settings.mode !== "accepting"
+      ? "mode"
+      : pausedUntil !== null
+        ? "paused"
+        : withinSchedule(settings.schedule, new Date(now))
+          ? null
+          : "schedule";
+
+  return { accepting: blockedBy === null, blockedBy, pausedUntil, schedule: settings.schedule };
+}
+
+/**
+ * The timestamp a pause of `minutes` ends at, or `null` for no pause. Stored
+ * rather than counted down in memory, so a restart in the middle of a pause
+ * does not resume claiming early.
+ */
+export function pauseUntil(minutes: number, now = Date.now()): number | null {
+  return minutes > 0 ? now + minutes * MINUTE_MS : null;
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { acceptState } from "./accepting";
 import { uploadImage } from "./comfy";
 import {
   AUTO_UPDATE,
@@ -177,10 +178,10 @@ async function runPoll() {
       }
     }
 
-    // Only the first mode claims. Heartbeats carry on either way, so the
-    // upstream still sees this host as alive — its queue simply is not drained
-    // from here.
-    if ((await loadSettings()).mode !== "accepting") {
+    // Only the first mode claims, and a pause or a daily window can withhold
+    // it further. Heartbeats carry on through all of it, so the upstream still
+    // sees this host as alive — its queue simply is not drained from here.
+    if (!acceptState(await loadSettings()).accepting) {
       await idle(POLL_INTERVAL_MS);
       continue;
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@
  */
 
 import { readFile, writeFile } from "node:fs/promises";
+import { isTimeOfDay } from "./accepting";
 import { STATE_FILE } from "./config";
 
 export type UpstreamConfig = {
@@ -50,6 +51,20 @@ export type RunMode =
 
 export const RUN_MODES: RunMode[] = ["accepting", "local", "paused"];
 
+/**
+ * The daily window in which job servers get work out of this machine. Off on a
+ * fresh install: a machine that is running accepts, which is the behaviour
+ * everyone had before there was a window at all.
+ */
+export type AcceptSchedule = {
+  enabled: boolean;
+  /** Local `HH:MM`. An end before the start crosses midnight. */
+  from: string;
+  to: string;
+};
+
+const EMPTY_SCHEDULE: AcceptSchedule = { enabled: false, from: "02:00", to: "08:00" };
+
 export type Settings = {
   activeWorkflow: string | null;
   /** Where ComfyUI is checked out. Empty until someone fills it in. */
@@ -65,6 +80,14 @@ export type Settings = {
    * up quietly claiming jobs again is the surprising behaviour.
    */
   mode: RunMode;
+  /** When the mode above is allowed to claim. */
+  schedule: AcceptSchedule;
+  /**
+   * Claiming is off until this timestamp, `null` when it is not. A stored
+   * deadline rather than a countdown, so a restart inside the pause does not
+   * quietly start claiming again.
+   */
+  pauseUntil: number | null;
   desktop: DesktopSettings;
 };
 
@@ -74,6 +97,8 @@ const EMPTY: Settings = {
   comfyCommand: "",
   upstreams: [],
   mode: "accepting",
+  schedule: EMPTY_SCHEDULE,
+  pauseUntil: null,
   desktop: { autostart: false, closeAction: "tray" },
 };
 
@@ -132,6 +157,18 @@ function normaliseMode(value: Partial<Settings> & { accepting?: unknown }): RunM
   return "accepting";
 }
 
+function normaliseSchedule(raw: unknown): AcceptSchedule {
+  const value = (raw ?? {}) as Partial<AcceptSchedule>;
+  return {
+    enabled: value.enabled === true,
+    // A time the file cannot describe falls back to the default rather than
+    // failing the load: the window is off by default, so nothing is lent out
+    // on a value nobody typed.
+    from: isTimeOfDay(value.from) ? value.from : EMPTY_SCHEDULE.from,
+    to: isTimeOfDay(value.to) ? value.to : EMPTY_SCHEDULE.to,
+  };
+}
+
 function normaliseDesktop(raw: unknown): DesktopSettings {
   const value = (raw ?? {}) as Partial<DesktopSettings>;
   return {
@@ -152,6 +189,8 @@ function normalise(raw: unknown): Settings {
     // missing key falls back to the environment.
     upstreams: upstreams ?? upstreamsFromEnv(),
     mode: normaliseMode(value),
+    schedule: normaliseSchedule(value.schedule),
+    pauseUntil: typeof value.pauseUntil === "number" ? value.pauseUntil : null,
     desktop: normaliseDesktop(value.desktop),
   };
 }

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -96,6 +96,12 @@ type State = {
   upstreams: UpstreamView[];
   settings: { comfyDir: string; comfyCommand: string };
   mode: RunMode;
+  accepting: {
+    accepting: boolean;
+    blockedBy: "mode" | "paused" | "schedule" | null;
+    pausedUntil: number | null;
+    schedule: { enabled: boolean; from: string; to: string };
+  };
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
 };
@@ -141,7 +147,14 @@ const nodes = {
   modePanel: el("mode-panel"),
   modeDot: el("mode-dot"),
   modeLabel: el("mode-label"),
+  modeGate: el("mode-gate"),
   modeNote: el("mode-note"),
+  acceptPause: el("accept-pause"),
+  acceptPauseState: el("accept-pause-state"),
+  acceptEnabled: el<HTMLInputElement>("accept-enabled"),
+  acceptFrom: el<HTMLInputElement>("accept-from"),
+  acceptTo: el<HTMLInputElement>("accept-to"),
+  acceptNote: el("accept-note"),
   desktopAutostart: el<HTMLInputElement>("desktop-autostart"),
   desktopNote: el("desktop-note"),
 };
@@ -167,6 +180,11 @@ function formatDuration(ms: number): string {
 
 function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString(locale());
+}
+
+/** Whole minutes still to go. Never zero: seconds left is still time left. */
+function minutesLeft(until: number): number {
+  return Math.max(1, Math.ceil((until - Date.now()) / 60_000));
 }
 
 /**
@@ -291,6 +309,16 @@ function renderVitals(state: State): void {
   const healthy = agent.upstreams.filter((server) => server.heartbeat?.ok).length;
   const agentTone = healthy === total ? "ok" : healthy > 0 ? "warn" : "bad";
 
+  // What is holding jobs back beats the mode here: "accepting" with a pause
+  // running is not what anyone glancing at the bar wants to be told.
+  const gate = state.accepting;
+  const work =
+    gate.blockedBy === "paused" && gate.pausedUntil !== null
+      ? { label: t("accept.paused", { minutes: minutesLeft(gate.pausedUntil) }), tone: "idle" }
+      : gate.blockedBy === "schedule"
+        ? { label: t("accept.outside"), tone: "idle" }
+        : { label: modeLabel(state.mode), tone: MODE_TONE[state.mode] };
+
   const chips = [
     chip(t("vitals.comfy"), esc(comfyStatusLabel(comfy.comfyStatus)), tone),
     chip(t("vitals.running"), pad(comfy.queueRunning)),
@@ -298,7 +326,7 @@ function renderVitals(state: State): void {
     total === 0
       ? chip(t("vitals.agent"), t("vitals.standalone"))
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
-    chip(t("vitals.work"), modeLabel(state.mode), MODE_TONE[state.mode]),
+    chip(t("vitals.work"), work.label, work.tone),
   ];
 
   if (comfyProcess.managed) {
@@ -658,6 +686,59 @@ function syncMode(state: State): void {
   for (const option of document.querySelectorAll<HTMLElement>("[data-mode]")) {
     option.setAttribute("aria-pressed", String(option.dataset["mode"] === state.mode));
   }
+
+  const gate = state.accepting;
+  nodes.modeGate.textContent =
+    gate.blockedBy === "paused" && gate.pausedUntil !== null
+      ? t("accept.gatePaused", { minutes: minutesLeft(gate.pausedUntil) })
+      : gate.blockedBy === "schedule"
+        ? t("accept.gateSchedule", { from: gate.schedule.from, to: gate.schedule.to })
+        : "";
+}
+
+// ---------------------------------------------------------------------------
+// Accepting — when the mode is allowed to claim
+// ---------------------------------------------------------------------------
+
+/** Held while a control is in flight, so a poll cannot flip it back. */
+let acceptBusy = false;
+
+function syncAccepting(state: State): void {
+  const { pausedUntil, schedule } = state.accepting;
+
+  nodes.acceptPauseState.textContent =
+    pausedUntil === null
+      ? t("accept.notPaused")
+      : t("accept.pausedUntil", {
+          time: formatTime(pausedUntil),
+          minutes: minutesLeft(pausedUntil),
+        });
+
+  // Nothing to resume from when nothing is on hold.
+  for (const button of nodes.acceptPause.querySelectorAll<HTMLButtonElement>('[data-pause="0"]')) {
+    button.disabled = pausedUntil === null;
+  }
+
+  if (acceptBusy) return;
+  nodes.acceptEnabled.checked = schedule.enabled;
+  // A time is saved as soon as it changes, so the only field worth leaving
+  // alone is the one being typed into.
+  if (document.activeElement !== nodes.acceptFrom) nodes.acceptFrom.value = schedule.from;
+  if (document.activeElement !== nodes.acceptTo) nodes.acceptTo.value = schedule.to;
+}
+
+/** Send one change, then let the next poll confirm it. */
+async function saveAccepting(path: string, body: unknown): Promise<void> {
+  acceptBusy = true;
+  const result = await post(path, body);
+  acceptBusy = false;
+
+  setNote(
+    nodes.acceptNote,
+    result.ok ? t("accept.saved") : (result.error ?? t("accept.saveFailed")),
+    !result.ok,
+  );
+  void poll();
 }
 
 // ---------------------------------------------------------------------------
@@ -760,6 +841,7 @@ function render(state: State): void {
   renderJobs(state);
   syncSettings(state);
   syncMode(state);
+  syncAccepting(state);
   syncDesktop(state);
   syncForm(state);
 }
@@ -858,7 +940,13 @@ onLangChange(() => {
 
   // Notes report something that has already happened, so they are cleared
   // rather than translated after the fact.
-  for (const note of [nodes.note, nodes.uploadNote, nodes.settingsNote, nodes.serversNote]) {
+  for (const note of [
+    nodes.note,
+    nodes.uploadNote,
+    nodes.settingsNote,
+    nodes.serversNote,
+    nodes.acceptNote,
+  ]) {
     setNote(note, "");
   }
 
@@ -1142,6 +1230,29 @@ nodes.desktopPanel.addEventListener("click", (event) => {
   ];
   if (choice) void saveDesktop("/api/desktop", { closeAction: choice });
 });
+
+nodes.acceptPause.addEventListener("click", (event) => {
+  const minutes = (event.target as HTMLElement).closest<HTMLElement>("[data-pause]")?.dataset[
+    "pause"
+  ];
+  if (minutes === undefined) return;
+  void saveAccepting("/api/accept/pause", { minutes: Number(minutes) });
+});
+
+nodes.acceptEnabled.addEventListener("change", () => {
+  void saveAccepting("/api/accept/schedule", { enabled: nodes.acceptEnabled.checked });
+});
+
+// Both go together: a window is the pair, and sending one of them alone would
+// save a half-edited window on the way to the other field.
+for (const input of [nodes.acceptFrom, nodes.acceptTo]) {
+  input.addEventListener("change", () => {
+    void saveAccepting("/api/accept/schedule", {
+      from: nodes.acceptFrom.value,
+      to: nodes.acceptTo.value,
+    });
+  });
+}
 
 // Ticking elapsed time for running jobs, kept out of the render pass so it
 // never rewrites the job list.

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -63,6 +63,46 @@ const STRINGS = {
   },
   "mode.saveFailed": { en: "could not change it", ja: "変更できませんでした" },
 
+  // When jobs are accepted, on top of the mode -------------------------------
+  "accept.title": { en: "Accepting jobs", ja: "ジョブの受付" },
+  "accept.help": {
+    en: "When job servers get work out of this machine. Runs you start here, and ComfyUI itself, are not affected.",
+    ja: "ジョブサーバーからの仕事をいつ受けるかの設定です。ここから始める実行と ComfyUI 自体には影響しません。",
+  },
+  "accept.pauseFor": { en: "Hold off for", ja: "一時停止" },
+  "accept.pause15": { en: "15 min", ja: "15分" },
+  "accept.pause30": { en: "30 min", ja: "30分" },
+  "accept.pause60": { en: "1 hour", ja: "1時間" },
+  "accept.resume": { en: "Resume now", ja: "すぐ再開" },
+  "accept.pausedUntil": {
+    en: "On hold until {time}, {minutes} min left.",
+    ja: "{time} まで停止中です。あと {minutes} 分。",
+  },
+  "accept.notPaused": { en: "Not on hold.", ja: "一時停止していません。" },
+  "accept.schedule": { en: "Every day", ja: "毎日" },
+  "accept.scheduleOn": {
+    en: "Only accept between these times",
+    ja: "この時間帯だけ受け付ける",
+  },
+  "accept.from": { en: "From", ja: "開始" },
+  "accept.to": { en: "To", ja: "終了" },
+  "accept.overnight": {
+    en: "An end before the start runs overnight — 22:00 to 06:00 is tonight until tomorrow morning.",
+    ja: "終了が開始より前なら日をまたぎます。22:00〜06:00 は今夜から翌朝までです。",
+  },
+  "accept.saved": { en: "saved", ja: "保存しました" },
+  "accept.saveFailed": { en: "could not save it", ja: "保存できませんでした" },
+  "accept.paused": { en: "on hold {minutes}m", ja: "停止中 あと{minutes}分" },
+  "accept.outside": { en: "outside the window", ja: "時間帯外" },
+  "accept.gatePaused": {
+    en: "Jobs are on hold for another {minutes} min. Runs started here still go.",
+    ja: "あと {minutes} 分はジョブを受けません。ここからの実行は動きます。",
+  },
+  "accept.gateSchedule": {
+    en: "Outside {from}–{to}, so nothing is claimed. Runs started here still go.",
+    ja: "{from}〜{to} の外なのでジョブは受けません。ここからの実行は動きます。",
+  },
+
   // The desktop menu, mirrored by the tray -----------------------------------
   "desktop.title": { en: "Desktop app", ja: "デスクトップアプリ" },
   "desktop.autostart": { en: "Start when the computer starts", ja: "PC 起動時に起動する" },

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -103,6 +103,9 @@
                 <span class="muted" data-i18n="mode.pausedNote"></span>
               </span>
             </button>
+            <!-- What is holding jobs back while the mode above says they are
+                 welcome: a pause running out, or the wrong time of day. -->
+            <p class="muted" id="mode-gate"></p>
             <p class="muted" id="mode-note"></p>
           </div>
         </div>
@@ -410,6 +413,50 @@
               </button>
               <p class="muted" id="servers-note"></p>
             </div>
+          </section>
+
+          <!-- The mode in the header says whether this machine takes work at
+               all. This says when, so nobody has to be sitting here to switch
+               it back. Both only ever hold jobs back — a run started here, and
+               ComfyUI itself, are untouched. -->
+          <section class="panel">
+            <div class="panel-head"><h2 data-i18n="accept.title">Accepting jobs</h2></div>
+            <p class="muted" data-i18n="accept.help"></p>
+
+            <p class="popover-label" data-i18n="accept.pauseFor">Hold off for</p>
+            <div class="actions" id="accept-pause">
+              <button type="button" class="ghost" data-pause="15" data-i18n="accept.pause15">
+                15 min
+              </button>
+              <button type="button" class="ghost" data-pause="30" data-i18n="accept.pause30">
+                30 min
+              </button>
+              <button type="button" class="ghost" data-pause="60" data-i18n="accept.pause60">
+                1 hour
+              </button>
+              <button type="button" class="ghost" data-pause="0" data-i18n="accept.resume">
+                Resume now
+              </button>
+            </div>
+            <p class="muted" id="accept-pause-state"></p>
+
+            <p class="popover-label" data-i18n="accept.schedule">Every day</p>
+            <label class="check">
+              <input type="checkbox" id="accept-enabled" />
+              <span data-i18n="accept.scheduleOn">Only accept between these times</span>
+            </label>
+            <div class="row">
+              <label class="field">
+                <span data-i18n="accept.from">From</span>
+                <input type="time" id="accept-from" />
+              </label>
+              <label class="field">
+                <span data-i18n="accept.to">To</span>
+                <input type="time" id="accept-to" />
+              </label>
+            </div>
+            <p class="muted" data-i18n="accept.overnight"></p>
+            <p class="muted" id="accept-note"></p>
           </section>
         </section>
       </main>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1,3 +1,4 @@
+import { MAX_PAUSE_MINUTES, acceptState, isTimeOfDay, pauseUntil } from "../accepting";
 import { agentSnapshot, applyUpstreamChange } from "../agent";
 import { interrupt, uploadImage, viewUrl } from "../comfy";
 import { comfyProcessState, startComfy, stopComfy } from "../comfy-process";
@@ -25,7 +26,7 @@ import {
 } from "../workflow";
 import { authorise } from "./guard";
 import index from "./index.html";
-import type { RunMode, UpstreamConfig } from "../settings";
+import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
 import type { RunParams } from "../types";
 
 function message(err: unknown): string {
@@ -49,6 +50,7 @@ async function handleState(): Promise<Response> {
     upstreams: publicUpstreams(settings),
     settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
     mode: settings.mode,
+    accepting: acceptState(settings),
     desktop: settings.desktop,
     jobs: listJobs(),
   });
@@ -202,6 +204,57 @@ async function handleMode(req: Request): Promise<Response> {
       await refreshStatus();
     }
     return Response.json({ mode: saved.mode });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * Hold off claiming for a while, then let it resume on its own. `0` minutes
+ * (or `null`) clears a pause that is still running.
+ *
+ * Deliberately not folded into `/api/mode`: the mode is what someone decided
+ * this machine is for, and a pause is a detour from it that ends by itself.
+ */
+async function handlePause(req: Request): Promise<Response> {
+  try {
+    const { minutes } = (await req.json()) as { minutes?: unknown };
+    const value = minutes === null || minutes === undefined ? 0 : minutes;
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return fail("minutes must be a number");
+    }
+    if (value < 0 || value > MAX_PAUSE_MINUTES) {
+      return fail(`minutes must be between 0 and ${MAX_PAUSE_MINUTES}`);
+    }
+
+    const saved = await saveSettings({ pauseUntil: pauseUntil(value) });
+    return Response.json({ accepting: acceptState(saved) });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * The daily window. Saved field by field like the desktop switches, so turning
+ * the window on does not need the times sent again, and fixing a time does not
+ * need the switch sent again.
+ */
+async function handleScheduleSave(req: Request): Promise<Response> {
+  try {
+    const body = (await req.json()) as Partial<AcceptSchedule>;
+    const current = (await loadSettings()).schedule;
+
+    if (body.enabled !== undefined && typeof body.enabled !== "boolean") {
+      return fail("enabled must be true or false");
+    }
+    const from = body.from ?? current.from;
+    const to = body.to ?? current.to;
+    if (!isTimeOfDay(from) || !isTimeOfDay(to)) return fail("from and to must be HH:MM");
+
+    const saved = await saveSettings({
+      schedule: { enabled: body.enabled ?? current.enabled, from, to },
+    });
+    return Response.json({ accepting: acceptState(saved) });
   } catch (err) {
     return fail(err);
   }
@@ -414,6 +467,8 @@ export function startUi() {
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
       "/api/mode": { POST: guarded(handleMode) },
+      "/api/accept/pause": { POST: guarded(handlePause) },
+      "/api/accept/schedule": { POST: guarded(handleScheduleSave) },
       "/api/desktop": { POST: guarded(handleDesktopSave) },
       "/api/comfy/start": { POST: guarded(handleComfyStart) },
       "/api/comfy/stop": { POST: guarded(handleComfyStop) },


### PR DESCRIPTION
Closes #3. Bottom of a stack of three — the next two are based on this branch and on each other, so this is the one to read first.

The mode in the header still says whether this machine takes work at all. What is new is **when**, under *Accepting jobs* on the Settings page:

- **Hold off for** 15 / 30 / 60 minutes, then claiming resumes on its own. The end time and the minutes left are shown, and *Resume now* clears it early.
- **Every day, only between two times.** An end before the start crosses midnight, so 22:00–06:00 reads as tonight until tomorrow morning rather than as a mistake.

How it is put together:

- `src/accepting.ts` is the single answer to "is this machine claiming right now": the mode first, then a hold, then the window. The agent, `/api/state` and the header all read that one function, so they cannot disagree about it.
- `mode` is never rewritten. Both controls are a gate in front of claiming, which is what lets the tray go on showing what a person chose while the machine stops and starts claiming on its own.
- Only claiming is gated. ComfyUI stays up, runs started here still go, and heartbeats carry on — the upstream still sees this host, it just gets nothing out of it.
- A hold is stored as its end timestamp rather than counted down in memory, so restarting the app inside one does not resume early.

Also here, because the stack needs it: CI runs on every pull request instead of only ones aimed at `main` and `dev`. A stacked PR targets the branch below it, and those names cannot be listed in the trigger.

Checked by hand against a running server: default accepting; a 30-minute hold reporting `blockedBy: "paused"`; *Resume now* clearing it; `minutes: 5000` refused; an 02:00–08:00 window blocking at 16:43 local; an overnight window covering now accepting; and all of it landing in `.state.json`.