### PR TITLE
feat(servers): test a job server's connection from its row

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ also polls for queued jobs, runs them through the active workflow and uploads
 the result — which is the point of the tray: the machine keeps serving with
 nothing on screen.
 
+Each row has a *Test* button. It sends one heartbeat there and then, so a wrong
+secret answers `HTTP 401` immediately instead of looking like an unreachable host
+until the next beat. It tests what is on screen, so a secret you have typed but
+not saved is the one tried; leaving the box blank tests the stored one.
+
 Several can be served at once. They are asked in the order the list puts them,
 so the top of the list is the priority: a server with work queued keeps this
 machine until it runs dry, and only then does the next one get a turn.

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -229,7 +229,10 @@ function outputUrl(output: RunOutput): string {
   return `/api/output?${query}`;
 }
 
-async function post(path: string, body?: unknown): Promise<{ ok: boolean; error?: string }> {
+async function post<T = unknown>(
+  path: string,
+  body?: unknown,
+): Promise<{ ok: boolean; error?: string; data?: T }> {
   try {
     const res = await fetch(path, {
       method: "POST",
@@ -239,8 +242,10 @@ async function post(path: string, body?: unknown): Promise<{ ok: boolean; error?
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
     });
-    const parsed = (await res.json().catch(() => ({}))) as { error?: string };
-    return res.ok ? { ok: true } : { ok: false, error: parsed.error ?? `HTTP ${res.status}` };
+    const parsed = (await res.json().catch(() => ({}))) as { error?: string } & T;
+    return res.ok
+      ? { ok: true, data: parsed }
+      : { ok: false, error: parsed.error ?? `HTTP ${res.status}` };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
@@ -444,7 +449,14 @@ function renderWorkflows(state: State): void {
 // Upstream servers — an editor, so polling must not overwrite what is typed
 // ---------------------------------------------------------------------------
 
-type ServerRow = UpstreamView & { secret: string };
+type UpstreamTest = { ok: boolean; ms: number; pendingJobs?: number; error?: string };
+
+/**
+ * A row as it stands on screen: the stored server, the secret box (blank means
+ * "keep the stored one"), and the last test of it. `testing` is held on the row
+ * rather than globally so testing one server leaves the others alone.
+ */
+type ServerRow = UpstreamView & { secret: string; testing?: boolean; test?: UpstreamTest };
 
 let serverRows: ServerRow[] | null = null;
 let serversDirty = false;
@@ -459,6 +471,23 @@ function heartbeatFor(state: State, row: ServerRow): string {
   return `<span class="state"><span class="dot ${beat.ok ? "ok" : "bad"}"></span>${
     beat.ok ? t("servers.up") : t("servers.down")
   }${waiting}</span>`;
+}
+
+/** The last test of this row, in its own words. Nothing until one is run. */
+function testResultFor(row: ServerRow): string {
+  if (row.testing) return `<p class="meta">${t("servers.testing")}</p>`;
+  if (!row.test) return "";
+
+  if (!row.test.ok) {
+    return `<p class="error">${t("servers.testFailed", {
+      error: esc(row.test.error ?? ""),
+    })}</p>`;
+  }
+  const queued =
+    row.test.pendingJobs === undefined
+      ? ""
+      : ` · ${t("servers.queued", { count: row.test.pendingJobs })}`;
+  return `<p class="meta">${t("servers.testOk", { ms: row.test.ms })}${queued}</p>`;
 }
 
 function renderServers(state: State): void {
@@ -477,6 +506,9 @@ function renderServers(state: State): void {
           <span class="mono muted">${pad(index + 1)}</span>
           ${heartbeatFor(state, row)}
           <span class="spacer"></span>
+          <button type="button" class="ghost" data-test-server="${index}">${t(
+            "servers.test",
+          )}</button>
           <button type="button" class="ghost" data-move="${index}" data-dir="-1" ${
             index === 0 ? "disabled" : ""
           } title="${t("servers.higher")}">↑</button>
@@ -515,9 +547,39 @@ function renderServers(state: State): void {
           <input type="checkbox" data-field="enabled" ${row.enabled ? "checked" : ""} />
           <span>${t("servers.enabled")}</span>
         </label>
+        ${testResultFor(row)}
       </div>`,
     )
     .join("")}</div>`;
+}
+
+/**
+ * Ask one server for a heartbeat now and keep the answer on its row. What is on
+ * screen is sent, so a secret typed a moment ago is what gets tried.
+ */
+async function testServer(index: number): Promise<void> {
+  const row = serverRows?.[index];
+  if (!row || !latestState) return;
+
+  row.testing = true;
+  row.test = undefined;
+  renderServers(latestState);
+
+  const result = await post<UpstreamTest>("/api/upstreams/test", {
+    id: row.id || undefined,
+    url: row.url,
+    hostId: row.hostId,
+    // Blank means the stored one, exactly as saving reads it.
+    secret: row.secret,
+  });
+
+  row.testing = false;
+  // A request the server refused outright — a row with no URL yet — is the same
+  // kind of answer as one it sent: it belongs on the row, not in the console.
+  row.test = result.ok
+    ? (result.data ?? { ok: true, ms: 0 })
+    : { ok: false, ms: 0, error: result.error ?? "" };
+  if (latestState) renderServers(latestState);
 }
 
 /** Copy what is on screen back into the model before any structural change. */
@@ -1087,6 +1149,13 @@ nodes.servers.addEventListener("click", (event) => {
       serversDirty = true;
       if (latestState) renderServers(latestState);
     }
+    return;
+  }
+
+  const test = target.closest<HTMLElement>("[data-test-server]");
+  if (test && serverRows) {
+    readServerInputs();
+    void testServer(Number(test.dataset["testServer"]));
     return;
   }
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -287,6 +287,10 @@ const STRINGS = {
   "servers.up": { en: "up", ja: "応答あり" },
   "servers.down": { en: "down", ja: "応答なし" },
   "servers.queued": { en: "{count} waiting", ja: "待ち {count} 件" },
+  "servers.test": { en: "Test", ja: "接続テスト" },
+  "servers.testing": { en: "testing…", ja: "テスト中…" },
+  "servers.testOk": { en: "answered in {ms} ms", ja: "{ms} ms で応答しました" },
+  "servers.testFailed": { en: "no answer — {error}", ja: "応答なし — {error}" },
 
   // Durations ---------------------------------------------------------------
   "time.seconds": { en: "{seconds}s", ja: "{seconds}秒" },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -24,6 +24,7 @@ import {
   saveWorkflowFile,
   setActiveWorkflow,
 } from "../workflow";
+import { testUpstream } from "../upstream";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -151,6 +152,41 @@ async function handleUpstreamsSave(req: Request): Promise<Response> {
     const saved = await saveSettings({ upstreams });
     await applyUpstreamChange();
     return Response.json({ upstreams: publicUpstreams(saved) });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * One heartbeat to a single server, sent now, so a wrong secret says so instead
+ * of looking like an unreachable host until the next scheduled beat.
+ *
+ * The row is taken as it stands on screen: a secret typed but not yet saved is
+ * what gets tested, and a blank one falls back to the stored value — the same
+ * rule the save path uses, so testing and saving cannot disagree about which
+ * secret they mean.
+ */
+async function handleUpstreamTest(req: Request): Promise<Response> {
+  try {
+    const input = (await req.json()) as UpstreamInput;
+    const settings = await loadSettings();
+    const stored = input.id
+      ? settings.upstreams.find((server) => server.id === input.id)
+      : undefined;
+
+    const url = (input.url ?? stored?.url ?? "").trim().replace(/\/$/, "");
+    if (!url) return fail("a URL is needed");
+    const hostId = (input.hostId ?? stored?.hostId ?? "").trim();
+    if (!hostId) return fail("a host id is needed");
+    const secret = (input.secret ?? "").trim() || stored?.secret || "";
+    if (!secret) return fail("a secret is needed");
+
+    const { comfyStatus, queueRunning, queuePending } = latestStatus();
+    const result = await testUpstream(
+      { name: url, url, hostId, secret },
+      { comfyStatus, queueRunning, queuePending },
+    );
+    return Response.json(result);
   } catch (err) {
     return fail(err);
   }
@@ -464,6 +500,7 @@ export function startUi() {
       "/api/workflows/delete": { POST: guarded(handleWorkflowDelete) },
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },
+      "/api/upstreams/test": { POST: guarded(handleUpstreamTest) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
       "/api/mode": { POST: guarded(handleMode) },

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -81,6 +81,60 @@ export async function sendHeartbeat(
   }
 }
 
+export type UpstreamTest = {
+  ok: boolean;
+  /** Round trip in milliseconds, however it ended. */
+  ms: number;
+  /** Jobs waiting for this host, when the server said. */
+  pendingJobs?: number;
+  /** Why it failed, as close to the server's own words as there are any. */
+  error?: string;
+};
+
+/** Enough of a rejection to tell a wrong secret from a wrong address. */
+const REASON_LIMIT = 120;
+
+/**
+ * One heartbeat, sent now, answering with why it failed rather than logging it.
+ *
+ * A separate call from {@link sendHeartbeat} on purpose: that one swallows
+ * failures because the poll loop must carry on regardless, and someone who has
+ * just typed a secret in wants the opposite — the status code, in the row.
+ */
+export async function testUpstream(
+  server: UpstreamServer,
+  status: ComfyStatusResult,
+): Promise<UpstreamTest> {
+  const started = Date.now();
+
+  try {
+    const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/heartbeat`, {
+      method: "POST",
+      headers: authHeaders(server),
+      body: JSON.stringify(status),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const ms = Date.now() - started;
+
+    if (!res.ok) {
+      const reason = (await res.text().catch(() => "")).trim().slice(0, REASON_LIMIT);
+      return {
+        ok: false,
+        ms,
+        error: reason ? `HTTP ${res.status} ${reason}` : `HTTP ${res.status}`,
+      };
+    }
+    const ack = (await res.json()) as HeartbeatAck;
+    return { ok: true, ms, pendingJobs: ack.pendingJobs };
+  } catch (err) {
+    return {
+      ok: false,
+      ms: Date.now() - started,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export async function claimJob(server: UpstreamServer): Promise<ClaimedJob | null> {
   try {
     const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/jobs/claim`, {


### PR DESCRIPTION
Closes #4. Stacked on #6 — its base is `feat/3-accepting-schedule`, so the diff here is only the test button.

Adding a job server meant typing a URL, a host id and a secret and then waiting up to 30 seconds for the next heartbeat to find out whether any of it was right, with a wrong secret and an unreachable host looking identical until then.

Each row now has a **Test** button. It sends one heartbeat immediately and reports in place: the round trip when the server answered, or the status and the reason when it did not.

- `testUpstream` in `src/upstream.ts` is separate from `sendHeartbeat` on purpose. That one swallows failures because the poll loop has to carry on regardless; someone who has just typed a secret wants the opposite.
- The route takes the row as it stands on screen, so a secret typed but not saved is what gets tried. A blank secret box falls back to the stored one — the same rule the save path uses, so testing and saving cannot mean different secrets.
- `post()` in the page now hands back the parsed body, so the result can be shown on the row instead of only ok/failed.

Checked against a stub job server: right secret → `ok` in 3 ms with `3 waiting`; wrong secret → `HTTP 401 bad secret`; a port with nothing on it → the connection error; a row with no URL or no secret → refused with which one is missing.