### PR TITLE
feat(runs): show how far the run in flight has got

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ change something.
 other. Handy for checking a workflow does what you think before a job server
 starts sending work.
 
+A run in flight carries a bar — the steps ComfyUI has done out of the steps it
+expects, and the node it is on — so a slow workflow can be told from a stuck one.
+Jobs claimed from a job server land in the same history, so they get the same
+bar, and the status bar carries the percentage on either page.
+
 The header switches the theme and the language, and the button beside them opens
 the app's own settings — the same switches the tray menu carries.
 

--- a/src/comfy.ts
+++ b/src/comfy.ts
@@ -1,3 +1,4 @@
+import { CLIENT_ID } from "./progress";
 import type { ApiWorkflow } from "./slots";
 import type { ComfyStatusResult, OutputKind, RunOutput } from "./types";
 
@@ -76,7 +77,9 @@ export async function queuePrompt(baseUrl: string, workflow: ApiWorkflow): Promi
   const res = await fetch(`${baseUrl}/prompt`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ prompt: workflow }),
+    // The client id is what makes ComfyUI address its progress messages at the
+    // socket in `progress.ts` rather than at nobody.
+    body: JSON.stringify({ prompt: workflow, client_id: CLIENT_ID }),
     signal: AbortSignal.timeout(30_000),
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { startAgent, stopAgent } from "./agent";
 import { startComfyWatch, stopComfy } from "./comfy-process";
 import { COMFY_URL, DATA_DIR, UI_ENABLED, WORKFLOW_DIR } from "./config";
 import { loadJobs } from "./jobs";
+import { startProgressWatch, stopProgressWatch } from "./progress";
 import { loadSettings } from "./settings";
 import { startStatusPolling } from "./status";
 import { startUi } from "./ui/server";
@@ -36,6 +37,7 @@ if (names.length === 0) {
 
 const statusTimer = startStatusPolling(STATUS_POLL_MS);
 const comfyWatch = startComfyWatch();
+startProgressWatch();
 
 if (UI_ENABLED) {
   const server = startUi();
@@ -54,6 +56,7 @@ function shutdown() {
   stopAgent();
   clearInterval(statusTimer);
   clearInterval(comfyWatch);
+  stopProgressWatch();
   void stopComfy();
   process.exit(0);
 }

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,145 @@
+/**
+ * How far along the run in flight is, read from ComfyUI's WebSocket.
+ *
+ * Over HTTP there are two facts and nothing between them: a prompt was queued,
+ * and later it was done. A run that takes minutes therefore looks the same at
+ * 5% as at 95%, which is the difference between slow and stuck. ComfyUI does
+ * say — over `/ws`, addressed to the client id the prompt was queued with — so
+ * prompts go out carrying {@link CLIENT_ID} and this listens as that client.
+ *
+ * All of it is best effort. A socket that drops takes no run with it: the prompt
+ * belongs to ComfyUI by then, and the only loss is hearing about steps until the
+ * reconnect lands.
+ */
+
+import { COMFY_URL } from "./config";
+
+/** This process, to ComfyUI: on the prompt body and on the socket alike. */
+export const CLIENT_ID = crypto.randomUUID();
+
+const RECONNECT_MS = 5000;
+
+/**
+ * Progress this old is not progress. ComfyUI says when a run ends, but a socket
+ * that died mid-run says nothing at all, and a bar frozen at 60% is worse than
+ * no bar.
+ */
+const STALE_MS = 60_000;
+
+export type RunProgress = {
+  /** Empty when ComfyUI did not name one; the UI then shows no bar. */
+  promptId: string;
+  /** Steps done and steps expected, as ComfyUI counts them. */
+  value: number;
+  max: number;
+  /** The node being executed, when a message named it. */
+  node: string | null;
+  at: number;
+};
+
+let latest: RunProgress | null = null;
+let socket: WebSocket | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let watching = false;
+
+export function latestProgress(): RunProgress | null {
+  if (latest && Date.now() - latest.at > STALE_MS) latest = null;
+  return latest;
+}
+
+type Message = {
+  type?: string;
+  data?: {
+    value?: number;
+    max?: number;
+    node?: string | null;
+    prompt_id?: string;
+  };
+};
+
+/** Unknown message types are ignored: ComfyUI sends plenty this does not need. */
+function handle(raw: string): void {
+  let message: Message;
+  try {
+    message = JSON.parse(raw) as Message;
+  } catch {
+    return;
+  }
+  const data = message.data ?? {};
+
+  switch (message.type) {
+    case "progress": {
+      if (typeof data.value !== "number" || typeof data.max !== "number") return;
+      latest = {
+        promptId: data.prompt_id ?? latest?.promptId ?? "",
+        value: data.value,
+        max: data.max,
+        node: data.node ?? null,
+        at: Date.now(),
+      };
+      return;
+    }
+
+    // A node started, or — with no node — the queue went quiet. The step count
+    // belonged to the node that just ended either way, so it is dropped.
+    case "executing": {
+      if (data.node === null || data.node === undefined) latest = null;
+      else if (latest) latest = { ...latest, node: data.node, at: Date.now() };
+      return;
+    }
+
+    case "execution_success":
+    case "execution_error":
+    case "execution_interrupted":
+      latest = null;
+      return;
+
+    default:
+      return;
+  }
+}
+
+function connect(): void {
+  if (!watching) return;
+
+  const retry = (): void => {
+    socket = null;
+    latest = null;
+    // ComfyUI being down is the normal case here rather than an error, so this
+    // says nothing and simply comes back. `timer` also makes the pair of events
+    // a failed connect fires — error, then close — schedule one attempt.
+    if (!watching || timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      connect();
+    }, RECONNECT_MS);
+  };
+
+  try {
+    socket = new WebSocket(`${COMFY_URL.replace(/^http/, "ws")}/ws?clientId=${CLIENT_ID}`);
+  } catch {
+    retry();
+    return;
+  }
+
+  socket.addEventListener("message", (event) => {
+    if (typeof event.data === "string") handle(event.data);
+  });
+  socket.addEventListener("close", retry);
+  socket.addEventListener("error", retry);
+}
+
+export function startProgressWatch(): void {
+  if (watching) return;
+  watching = true;
+  connect();
+}
+
+export function stopProgressWatch(): void {
+  watching = false;
+  if (timer) clearTimeout(timer);
+  timer = null;
+  socket?.close();
+  socket = null;
+  latest = null;
+}

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -102,6 +102,14 @@ type State = {
     pausedUntil: number | null;
     schedule: { enabled: boolean; from: string; to: string };
   };
+  /** How far the run in flight has got, or null when nothing is reporting. */
+  progress: {
+    promptId: string;
+    value: number;
+    max: number;
+    node: string | null;
+    at: number;
+  } | null;
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
 };
@@ -180,6 +188,11 @@ function formatDuration(ms: number): string {
 
 function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString(locale());
+}
+
+/** Whole percent, clamped — a step past the max would otherwise overflow the bar. */
+function progressPercent(progress: { value: number; max: number }): number {
+  return Math.min(100, Math.max(0, Math.round((progress.value / progress.max) * 100)));
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -333,6 +346,10 @@ function renderVitals(state: State): void {
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
     chip(t("vitals.work"), work.label, work.tone),
   ];
+
+  if (state.progress && state.progress.max > 0) {
+    chips.push(chip(t("vitals.progress"), `${progressPercent(state.progress)}%`, "run"));
+  }
 
   if (comfyProcess.managed) {
     chips.push(chip(t("vitals.process"), `pid ${comfyProcess.pid ?? "?"}`, "run"));
@@ -643,7 +660,25 @@ function jobError(job: JobRecord): string {
   return job.error ? `<p class="error">${esc(job.error)}</p>` : "";
 }
 
-function jobEntry(job: JobRecord, withDelete: boolean): string {
+/**
+ * The bar under a running row, and nothing at all otherwise. Matched by prompt
+ * id: ComfyUI reports on the prompt it is executing, which is only this job when
+ * the two ids agree — anything else on that queue is not ours to draw.
+ */
+function progressBar(job: JobRecord, progress: State["progress"]): string {
+  if (job.state !== "running" || !progress || progress.max <= 0) return "";
+  if (!progress.promptId || progress.promptId !== job.promptId) return "";
+
+  const percent = progressPercent(progress);
+  return `<div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${percent}">
+      <span style="width: ${percent}%"></span>
+    </div>
+    <p class="meta">${t("jobs.progress", { percent, value: progress.value, max: progress.max })}${
+      progress.node ? ` · ${t("jobs.node", { node: esc(progress.node) })}` : ""
+    }</p>`;
+}
+
+function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress"]): string {
   const tone = job.state === "running" ? "run" : job.state === "succeeded" ? "ok" : "bad";
   const origin =
     job.source === "upstream"
@@ -668,6 +703,7 @@ function jobEntry(job: JobRecord, withDelete: boolean): string {
     <p class="meta">${formatTime(job.startedAt)} · ${timing}${origin}${
       job.promptId ? ` · ${t("jobs.prompt", { id: esc(job.promptId.slice(0, 8)) })}` : ""
     }</p>
+    ${progressBar(job, progress)}
     ${jobError(job)}
     ${job.outputs?.length ? renderOutputs(job.outputs) : ""}
   </div>`;
@@ -678,7 +714,7 @@ function renderJobs(state: State): void {
     renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${t("jobs.empty")}</p>`);
     return;
   }
-  const html = state.jobs.map((job) => jobEntry(job, true)).join("");
+  const html = state.jobs.map((job) => jobEntry(job, true, state.progress)).join("");
   renderIfChanged(nodes.jobs, "jobs", `<div class="ledger">${html}</div>`);
 }
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -129,6 +129,7 @@ const STRINGS = {
   "vitals.process": { en: "process", ja: "プロセス" },
   "vitals.access": { en: "access", ja: "アクセス" },
   "vitals.work": { en: "work", ja: "受付" },
+  "vitals.progress": { en: "progress", ja: "進捗" },
   "vitals.tokenNeeded": {
     en: "open this page as ?token=<UI_TOKEN>",
     ja: "?token=<UI_TOKEN> を付けて開いてください",
@@ -179,6 +180,11 @@ const STRINGS = {
   "jobs.ui": { en: "UI", ja: "UI" },
   "jobs.upstream": { en: "upstream", ja: "上流" },
   "jobs.prompt": { en: "prompt {id}", ja: "prompt {id}" },
+  "jobs.progress": {
+    en: "{percent}% · step {value}/{max}",
+    ja: "{percent}% · {value}/{max} ステップ",
+  },
+  "jobs.node": { en: "node {node}", ja: "ノード {node}" },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -12,6 +12,7 @@ import {
   removeJob,
   startJob,
 } from "../jobs";
+import { latestProgress } from "../progress";
 import { RUN_MODES, loadSettings, newUpstreamId, publicUpstreams, saveSettings } from "../settings";
 import { latestStatus, refreshStatus } from "../status";
 import {
@@ -52,6 +53,7 @@ async function handleState(): Promise<Response> {
     settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
     mode: settings.mode,
     accepting: acceptState(settings),
+    progress: latestProgress(),
     desktop: settings.desktop,
     jobs: listJobs(),
   });

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -912,6 +912,23 @@ button.ghost.danger:hover:not(:disabled) {
   accent-color: var(--primary);
 }
 
+/* How far along the run in flight is, when ComfyUI is counting steps. */
+.bar {
+  height: 0.375rem;
+  margin-top: var(--space-2xs);
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: var(--muted);
+}
+
+.bar > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--primary);
+  transition: width var(--dur-mid) var(--ease-out);
+}
+
 /* The child process's own words, so a wrong command explains itself. */
 .log {
   max-height: 14rem;


### PR DESCRIPTION
Closes #5. Top of the stack, on #7 — its base is `feat/4-upstream-test`, so the diff here is only the progress work.

Over HTTP there were two facts and nothing between them: a prompt was queued, and later it was done. A run that takes minutes therefore looked the same at 5% as at 95%, which is the difference between slow and stuck.

- `src/progress.ts` keeps a socket open to ComfyUI's `/ws` and holds the latest `progress` / `executing` message. Prompts now go out with the same `client_id`, which is what makes ComfyUI address those messages at us.
- `/api/state` carries `progress`, and the page draws a bar on the running row — steps done out of steps expected, plus the node — and a percentage chip in the status bar, so it is visible from either page.
- Matched by prompt id, so another client's run on the same ComfyUI is not drawn as ours.
- Best effort throughout: a dropped socket takes no run with it, reconnects after five seconds without logging on every attempt, and progress older than a minute is dropped rather than left frozen at 60%.

Jobs claimed from a job server land in the same history, so they get the same bar — which is the case that matters when the window is closed and the machine is serving.

Checked against a stub ComfyUI with a WebSocket: 9/20 and 20/20 arriving; `executing` with a null node clearing it; junk frames and unknown types ignored; and after killing and restarting that stub, progress arriving again on the reconnected socket.