### PR TITLE
ci: close the issues a pull request answers on merge into dev

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,67 @@
+name: Close issues
+
+# `Closes #12` in a pull request closes that issue only when the pull request is
+# merged into the default branch — and that is `main`, which receives releases
+# rather than work. Every pull request here lands on `dev`, so this does what
+# GitHub would have done if `dev` were the default.
+#
+# `pull_request_target`, not `pull_request`: a pull request from a fork gets a
+# read-only token, which cannot close anything. Nothing from the pull request is
+# checked out or run here, so running in the base context brings no risk.
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [dev]
+
+jobs:
+  close:
+    name: Close what it answers
+    # Closing a pull request without merging it answers nothing.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Close the issues the pull request names
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          # Through the environment rather than inlined: the body is whatever
+          # somebody typed, and `${{ }}` pasted into a script would run it.
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          issues=$(printf '%s' "$BODY" |
+            grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?) +#[0-9]+' |
+            grep -oE '[0-9]+' | sort -un)
+
+          if [ -z "$issues" ]; then
+            echo "#$NUMBER names no issue to close."
+            exit 0
+          fi
+
+          for issue in $issues; do
+            # The issues API answers for pull requests too, which is how one that
+            # is really a pull request is told apart from an issue.
+            info=$(gh api "repos/$REPO/issues/$issue" 2>/dev/null) || info='{}'
+            state=$(jq -r '.state // "missing"' <<< "$info")
+
+            if [ "$(jq -r 'if .pull_request then "yes" else "no" end' <<< "$info")" = yes ]; then
+              echo "#$issue is a pull request — left alone."
+              continue
+            fi
+            # Already closed by hand, or a number that names nothing: neither is
+            # a reason to fail a merge that has already happened.
+            if [ "$state" != open ]; then
+              echo "#$issue is $state — left alone."
+              continue
+            fi
+
+            gh issue close "$issue" --repo "$REPO" --comment \
+              "Closed by #$NUMBER, merged into \`dev\`. It reaches \`main\` with the next release."
+            echo "Closed #$issue." >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ and a pull request for what its branch does as a whole. Those three often read
 the same, which is the point: an issue and the work that answers it are easy to
 line up. Reasoning goes in the body, never in the title.
 
+Titles are English. A body can be in whichever language the discussion is in —
+Japanese is common here — since it is read by whoever is looking at that issue
+rather than by everyone scanning a list.
+
 ## Checks
 
 `lefthook` runs oxlint and oxfmt over staged files on commit. CI repeats them


### PR DESCRIPTION
Closes #11.

`Closes #12` は PR が**デフォルトブランチ**にマージされたときだけ効きます。ここのデフォルトは `main` で、`main` はリリースしか受け取らないため、`dev` で解決した issue は手で閉じるまで開いたままでした。このワークフローは、`dev` がデフォルトだったら GitHub がやっていたことを代わりに行います。`dev` 向けの PR がマージされたら、本文のクロージングキーワードを読んで該当 issue を閉じ、どの PR で閉じたかをコメントに残します。

- キーワードは GitHub と同じ扱いです（close/closes/closed、fix/fixes/fixed、resolve/resolves/resolved + `#番号`）。裸の `#8` は言及であってキーワードではないので、本文の「stacked on #6」のような行では何も閉じません。
- 実は PR だった番号、すでに閉じている issue、存在しない番号は、それぞれ理由を出力してスキップします。終わったマージの後始末で run を落としても得がないためです。
- `pull_request` ではなく `pull_request_target` を使います。fork からの PR では token が読み取り専用になり、issue を閉じられないからです。PR のコードは checkout も実行もしないので、base コンテキストで動かしてもリスクは増えません。
- 本文は環境変数でスクリプトに渡します。`${{ github.event.pull_request.body }}` をスクリプトに直接埋め込むと、書かれた内容がそのまま実行されてしまいます。

確認したこと: 現在の #6 / #7 / #8 / #10 の本文にパーサーとスキップ判定をかけ、それぞれ自分の issue 番号だけが出ること、`#10` は PR と判定されること、`#999` は何も指していないと判定されることを確認しました。

もう1つ、`docs(contributing)` のコミットで「タイトルは英語のコンベンショナル、本文は日本語でもよい」を CONTRIBUTING に書き足しています。PR を1本増やさないためにここに同梱しました。

このワークフローは `dev` に入って初めて効きます。`main` へのリリースマージには何も要りません（その時点で issue は閉じ終わっているため）。
