### PR TITLE
feat: land the upstream test and the run progress on dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ also polls for queued jobs, runs them through the active workflow and uploads
 the result — which is the point of the tray: the machine keeps serving with
 nothing on screen.
 
+Each row has a *Test* button. It sends one heartbeat there and then, so a wrong
+secret answers `HTTP 401` immediately instead of looking like an unreachable host
+until the next beat. It tests what is on screen, so a secret you have typed but
+not saved is the one tried; leaving the box blank tests the stored one.
+
 Several can be served at once. They are asked in the order the list puts them,
 so the top of the list is the priority: a server with work queued keeps this
 machine until it runs dry, and only then does the next one get a turn.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ change something.
 other. Handy for checking a workflow does what you think before a job server
 starts sending work.
 
+A run in flight carries a bar — the steps ComfyUI has done out of the steps it
+expects, and the node it is on — so a slow workflow can be told from a stuck one.
+Jobs claimed from a job server land in the same history, so they get the same
+bar, and the status bar carries the percentage on either page.
+
 The header switches the theme and the language, and the button beside them opens
 the app's own settings — the same switches the tray menu carries.
 

--- a/src/comfy.ts
+++ b/src/comfy.ts
@@ -1,3 +1,4 @@
+import { CLIENT_ID } from "./progress";
 import type { ApiWorkflow } from "./slots";
 import type { ComfyStatusResult, OutputKind, RunOutput } from "./types";
 
@@ -76,7 +77,9 @@ export async function queuePrompt(baseUrl: string, workflow: ApiWorkflow): Promi
   const res = await fetch(`${baseUrl}/prompt`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ prompt: workflow }),
+    // The client id is what makes ComfyUI address its progress messages at the
+    // socket in `progress.ts` rather than at nobody.
+    body: JSON.stringify({ prompt: workflow, client_id: CLIENT_ID }),
     signal: AbortSignal.timeout(30_000),
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { startAgent, stopAgent } from "./agent";
 import { startComfyWatch, stopComfy } from "./comfy-process";
 import { COMFY_URL, DATA_DIR, UI_ENABLED, WORKFLOW_DIR } from "./config";
 import { loadJobs } from "./jobs";
+import { startProgressWatch, stopProgressWatch } from "./progress";
 import { loadSettings } from "./settings";
 import { startStatusPolling } from "./status";
 import { startUi } from "./ui/server";
@@ -36,6 +37,7 @@ if (names.length === 0) {
 
 const statusTimer = startStatusPolling(STATUS_POLL_MS);
 const comfyWatch = startComfyWatch();
+startProgressWatch();
 
 if (UI_ENABLED) {
   const server = startUi();
@@ -54,6 +56,7 @@ function shutdown() {
   stopAgent();
   clearInterval(statusTimer);
   clearInterval(comfyWatch);
+  stopProgressWatch();
   void stopComfy();
   process.exit(0);
 }

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,145 @@
+/**
+ * How far along the run in flight is, read from ComfyUI's WebSocket.
+ *
+ * Over HTTP there are two facts and nothing between them: a prompt was queued,
+ * and later it was done. A run that takes minutes therefore looks the same at
+ * 5% as at 95%, which is the difference between slow and stuck. ComfyUI does
+ * say — over `/ws`, addressed to the client id the prompt was queued with — so
+ * prompts go out carrying {@link CLIENT_ID} and this listens as that client.
+ *
+ * All of it is best effort. A socket that drops takes no run with it: the prompt
+ * belongs to ComfyUI by then, and the only loss is hearing about steps until the
+ * reconnect lands.
+ */
+
+import { COMFY_URL } from "./config";
+
+/** This process, to ComfyUI: on the prompt body and on the socket alike. */
+export const CLIENT_ID = crypto.randomUUID();
+
+const RECONNECT_MS = 5000;
+
+/**
+ * Progress this old is not progress. ComfyUI says when a run ends, but a socket
+ * that died mid-run says nothing at all, and a bar frozen at 60% is worse than
+ * no bar.
+ */
+const STALE_MS = 60_000;
+
+export type RunProgress = {
+  /** Empty when ComfyUI did not name one; the UI then shows no bar. */
+  promptId: string;
+  /** Steps done and steps expected, as ComfyUI counts them. */
+  value: number;
+  max: number;
+  /** The node being executed, when a message named it. */
+  node: string | null;
+  at: number;
+};
+
+let latest: RunProgress | null = null;
+let socket: WebSocket | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let watching = false;
+
+export function latestProgress(): RunProgress | null {
+  if (latest && Date.now() - latest.at > STALE_MS) latest = null;
+  return latest;
+}
+
+type Message = {
+  type?: string;
+  data?: {
+    value?: number;
+    max?: number;
+    node?: string | null;
+    prompt_id?: string;
+  };
+};
+
+/** Unknown message types are ignored: ComfyUI sends plenty this does not need. */
+function handle(raw: string): void {
+  let message: Message;
+  try {
+    message = JSON.parse(raw) as Message;
+  } catch {
+    return;
+  }
+  const data = message.data ?? {};
+
+  switch (message.type) {
+    case "progress": {
+      if (typeof data.value !== "number" || typeof data.max !== "number") return;
+      latest = {
+        promptId: data.prompt_id ?? latest?.promptId ?? "",
+        value: data.value,
+        max: data.max,
+        node: data.node ?? null,
+        at: Date.now(),
+      };
+      return;
+    }
+
+    // A node started, or — with no node — the queue went quiet. The step count
+    // belonged to the node that just ended either way, so it is dropped.
+    case "executing": {
+      if (data.node === null || data.node === undefined) latest = null;
+      else if (latest) latest = { ...latest, node: data.node, at: Date.now() };
+      return;
+    }
+
+    case "execution_success":
+    case "execution_error":
+    case "execution_interrupted":
+      latest = null;
+      return;
+
+    default:
+      return;
+  }
+}
+
+function connect(): void {
+  if (!watching) return;
+
+  const retry = (): void => {
+    socket = null;
+    latest = null;
+    // ComfyUI being down is the normal case here rather than an error, so this
+    // says nothing and simply comes back. `timer` also makes the pair of events
+    // a failed connect fires — error, then close — schedule one attempt.
+    if (!watching || timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      connect();
+    }, RECONNECT_MS);
+  };
+
+  try {
+    socket = new WebSocket(`${COMFY_URL.replace(/^http/, "ws")}/ws?clientId=${CLIENT_ID}`);
+  } catch {
+    retry();
+    return;
+  }
+
+  socket.addEventListener("message", (event) => {
+    if (typeof event.data === "string") handle(event.data);
+  });
+  socket.addEventListener("close", retry);
+  socket.addEventListener("error", retry);
+}
+
+export function startProgressWatch(): void {
+  if (watching) return;
+  watching = true;
+  connect();
+}
+
+export function stopProgressWatch(): void {
+  watching = false;
+  if (timer) clearTimeout(timer);
+  timer = null;
+  socket?.close();
+  socket = null;
+  latest = null;
+}

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -102,6 +102,14 @@ type State = {
     pausedUntil: number | null;
     schedule: { enabled: boolean; from: string; to: string };
   };
+  /** How far the run in flight has got, or null when nothing is reporting. */
+  progress: {
+    promptId: string;
+    value: number;
+    max: number;
+    node: string | null;
+    at: number;
+  } | null;
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
 };
@@ -180,6 +188,11 @@ function formatDuration(ms: number): string {
 
 function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString(locale());
+}
+
+/** Whole percent, clamped — a step past the max would otherwise overflow the bar. */
+function progressPercent(progress: { value: number; max: number }): number {
+  return Math.min(100, Math.max(0, Math.round((progress.value / progress.max) * 100)));
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -333,6 +346,10 @@ function renderVitals(state: State): void {
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
     chip(t("vitals.work"), work.label, work.tone),
   ];
+
+  if (state.progress && state.progress.max > 0) {
+    chips.push(chip(t("vitals.progress"), `${progressPercent(state.progress)}%`, "run"));
+  }
 
   if (comfyProcess.managed) {
     chips.push(chip(t("vitals.process"), `pid ${comfyProcess.pid ?? "?"}`, "run"));
@@ -643,7 +660,25 @@ function jobError(job: JobRecord): string {
   return job.error ? `<p class="error">${esc(job.error)}</p>` : "";
 }
 
-function jobEntry(job: JobRecord, withDelete: boolean): string {
+/**
+ * The bar under a running row, and nothing at all otherwise. Matched by prompt
+ * id: ComfyUI reports on the prompt it is executing, which is only this job when
+ * the two ids agree — anything else on that queue is not ours to draw.
+ */
+function progressBar(job: JobRecord, progress: State["progress"]): string {
+  if (job.state !== "running" || !progress || progress.max <= 0) return "";
+  if (!progress.promptId || progress.promptId !== job.promptId) return "";
+
+  const percent = progressPercent(progress);
+  return `<div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${percent}">
+      <span style="width: ${percent}%"></span>
+    </div>
+    <p class="meta">${t("jobs.progress", { percent, value: progress.value, max: progress.max })}${
+      progress.node ? ` · ${t("jobs.node", { node: esc(progress.node) })}` : ""
+    }</p>`;
+}
+
+function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress"]): string {
   const tone = job.state === "running" ? "run" : job.state === "succeeded" ? "ok" : "bad";
   const origin =
     job.source === "upstream"
@@ -668,6 +703,7 @@ function jobEntry(job: JobRecord, withDelete: boolean): string {
     <p class="meta">${formatTime(job.startedAt)} · ${timing}${origin}${
       job.promptId ? ` · ${t("jobs.prompt", { id: esc(job.promptId.slice(0, 8)) })}` : ""
     }</p>
+    ${progressBar(job, progress)}
     ${jobError(job)}
     ${job.outputs?.length ? renderOutputs(job.outputs) : ""}
   </div>`;
@@ -678,7 +714,7 @@ function renderJobs(state: State): void {
     renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${t("jobs.empty")}</p>`);
     return;
   }
-  const html = state.jobs.map((job) => jobEntry(job, true)).join("");
+  const html = state.jobs.map((job) => jobEntry(job, true, state.progress)).join("");
   renderIfChanged(nodes.jobs, "jobs", `<div class="ledger">${html}</div>`);
 }
 

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -229,7 +229,10 @@ function outputUrl(output: RunOutput): string {
   return `/api/output?${query}`;
 }
 
-async function post(path: string, body?: unknown): Promise<{ ok: boolean; error?: string }> {
+async function post<T = unknown>(
+  path: string,
+  body?: unknown,
+): Promise<{ ok: boolean; error?: string; data?: T }> {
   try {
     const res = await fetch(path, {
       method: "POST",
@@ -239,8 +242,10 @@ async function post(path: string, body?: unknown): Promise<{ ok: boolean; error?
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
     });
-    const parsed = (await res.json().catch(() => ({}))) as { error?: string };
-    return res.ok ? { ok: true } : { ok: false, error: parsed.error ?? `HTTP ${res.status}` };
+    const parsed = (await res.json().catch(() => ({}))) as { error?: string } & T;
+    return res.ok
+      ? { ok: true, data: parsed }
+      : { ok: false, error: parsed.error ?? `HTTP ${res.status}` };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
@@ -444,7 +449,14 @@ function renderWorkflows(state: State): void {
 // Upstream servers — an editor, so polling must not overwrite what is typed
 // ---------------------------------------------------------------------------
 
-type ServerRow = UpstreamView & { secret: string };
+type UpstreamTest = { ok: boolean; ms: number; pendingJobs?: number; error?: string };
+
+/**
+ * A row as it stands on screen: the stored server, the secret box (blank means
+ * "keep the stored one"), and the last test of it. `testing` is held on the row
+ * rather than globally so testing one server leaves the others alone.
+ */
+type ServerRow = UpstreamView & { secret: string; testing?: boolean; test?: UpstreamTest };
 
 let serverRows: ServerRow[] | null = null;
 let serversDirty = false;
@@ -459,6 +471,23 @@ function heartbeatFor(state: State, row: ServerRow): string {
   return `<span class="state"><span class="dot ${beat.ok ? "ok" : "bad"}"></span>${
     beat.ok ? t("servers.up") : t("servers.down")
   }${waiting}</span>`;
+}
+
+/** The last test of this row, in its own words. Nothing until one is run. */
+function testResultFor(row: ServerRow): string {
+  if (row.testing) return `<p class="meta">${t("servers.testing")}</p>`;
+  if (!row.test) return "";
+
+  if (!row.test.ok) {
+    return `<p class="error">${t("servers.testFailed", {
+      error: esc(row.test.error ?? ""),
+    })}</p>`;
+  }
+  const queued =
+    row.test.pendingJobs === undefined
+      ? ""
+      : ` · ${t("servers.queued", { count: row.test.pendingJobs })}`;
+  return `<p class="meta">${t("servers.testOk", { ms: row.test.ms })}${queued}</p>`;
 }
 
 function renderServers(state: State): void {
@@ -477,6 +506,9 @@ function renderServers(state: State): void {
           <span class="mono muted">${pad(index + 1)}</span>
           ${heartbeatFor(state, row)}
           <span class="spacer"></span>
+          <button type="button" class="ghost" data-test-server="${index}">${t(
+            "servers.test",
+          )}</button>
           <button type="button" class="ghost" data-move="${index}" data-dir="-1" ${
             index === 0 ? "disabled" : ""
           } title="${t("servers.higher")}">↑</button>
@@ -515,9 +547,39 @@ function renderServers(state: State): void {
           <input type="checkbox" data-field="enabled" ${row.enabled ? "checked" : ""} />
           <span>${t("servers.enabled")}</span>
         </label>
+        ${testResultFor(row)}
       </div>`,
     )
     .join("")}</div>`;
+}
+
+/**
+ * Ask one server for a heartbeat now and keep the answer on its row. What is on
+ * screen is sent, so a secret typed a moment ago is what gets tried.
+ */
+async function testServer(index: number): Promise<void> {
+  const row = serverRows?.[index];
+  if (!row || !latestState) return;
+
+  row.testing = true;
+  row.test = undefined;
+  renderServers(latestState);
+
+  const result = await post<UpstreamTest>("/api/upstreams/test", {
+    id: row.id || undefined,
+    url: row.url,
+    hostId: row.hostId,
+    // Blank means the stored one, exactly as saving reads it.
+    secret: row.secret,
+  });
+
+  row.testing = false;
+  // A request the server refused outright — a row with no URL yet — is the same
+  // kind of answer as one it sent: it belongs on the row, not in the console.
+  row.test = result.ok
+    ? (result.data ?? { ok: true, ms: 0 })
+    : { ok: false, ms: 0, error: result.error ?? "" };
+  if (latestState) renderServers(latestState);
 }
 
 /** Copy what is on screen back into the model before any structural change. */
@@ -1087,6 +1149,13 @@ nodes.servers.addEventListener("click", (event) => {
       serversDirty = true;
       if (latestState) renderServers(latestState);
     }
+    return;
+  }
+
+  const test = target.closest<HTMLElement>("[data-test-server]");
+  if (test && serverRows) {
+    readServerInputs();
+    void testServer(Number(test.dataset["testServer"]));
     return;
   }
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -287,6 +287,10 @@ const STRINGS = {
   "servers.up": { en: "up", ja: "応答あり" },
   "servers.down": { en: "down", ja: "応答なし" },
   "servers.queued": { en: "{count} waiting", ja: "待ち {count} 件" },
+  "servers.test": { en: "Test", ja: "接続テスト" },
+  "servers.testing": { en: "testing…", ja: "テスト中…" },
+  "servers.testOk": { en: "answered in {ms} ms", ja: "{ms} ms で応答しました" },
+  "servers.testFailed": { en: "no answer — {error}", ja: "応答なし — {error}" },
 
   // Durations ---------------------------------------------------------------
   "time.seconds": { en: "{seconds}s", ja: "{seconds}秒" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -129,6 +129,7 @@ const STRINGS = {
   "vitals.process": { en: "process", ja: "プロセス" },
   "vitals.access": { en: "access", ja: "アクセス" },
   "vitals.work": { en: "work", ja: "受付" },
+  "vitals.progress": { en: "progress", ja: "進捗" },
   "vitals.tokenNeeded": {
     en: "open this page as ?token=<UI_TOKEN>",
     ja: "?token=<UI_TOKEN> を付けて開いてください",
@@ -179,6 +180,11 @@ const STRINGS = {
   "jobs.ui": { en: "UI", ja: "UI" },
   "jobs.upstream": { en: "upstream", ja: "上流" },
   "jobs.prompt": { en: "prompt {id}", ja: "prompt {id}" },
+  "jobs.progress": {
+    en: "{percent}% · step {value}/{max}",
+    ja: "{percent}% · {value}/{max} ステップ",
+  },
+  "jobs.node": { en: "node {node}", ja: "ノード {node}" },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -12,6 +12,7 @@ import {
   removeJob,
   startJob,
 } from "../jobs";
+import { latestProgress } from "../progress";
 import { RUN_MODES, loadSettings, newUpstreamId, publicUpstreams, saveSettings } from "../settings";
 import { latestStatus, refreshStatus } from "../status";
 import {
@@ -52,6 +53,7 @@ async function handleState(): Promise<Response> {
     settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
     mode: settings.mode,
     accepting: acceptState(settings),
+    progress: latestProgress(),
     desktop: settings.desktop,
     jobs: listJobs(),
   });

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -24,6 +24,7 @@ import {
   saveWorkflowFile,
   setActiveWorkflow,
 } from "../workflow";
+import { testUpstream } from "../upstream";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -151,6 +152,41 @@ async function handleUpstreamsSave(req: Request): Promise<Response> {
     const saved = await saveSettings({ upstreams });
     await applyUpstreamChange();
     return Response.json({ upstreams: publicUpstreams(saved) });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * One heartbeat to a single server, sent now, so a wrong secret says so instead
+ * of looking like an unreachable host until the next scheduled beat.
+ *
+ * The row is taken as it stands on screen: a secret typed but not yet saved is
+ * what gets tested, and a blank one falls back to the stored value — the same
+ * rule the save path uses, so testing and saving cannot disagree about which
+ * secret they mean.
+ */
+async function handleUpstreamTest(req: Request): Promise<Response> {
+  try {
+    const input = (await req.json()) as UpstreamInput;
+    const settings = await loadSettings();
+    const stored = input.id
+      ? settings.upstreams.find((server) => server.id === input.id)
+      : undefined;
+
+    const url = (input.url ?? stored?.url ?? "").trim().replace(/\/$/, "");
+    if (!url) return fail("a URL is needed");
+    const hostId = (input.hostId ?? stored?.hostId ?? "").trim();
+    if (!hostId) return fail("a host id is needed");
+    const secret = (input.secret ?? "").trim() || stored?.secret || "";
+    if (!secret) return fail("a secret is needed");
+
+    const { comfyStatus, queueRunning, queuePending } = latestStatus();
+    const result = await testUpstream(
+      { name: url, url, hostId, secret },
+      { comfyStatus, queueRunning, queuePending },
+    );
+    return Response.json(result);
   } catch (err) {
     return fail(err);
   }
@@ -464,6 +500,7 @@ export function startUi() {
       "/api/workflows/delete": { POST: guarded(handleWorkflowDelete) },
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },
+      "/api/upstreams/test": { POST: guarded(handleUpstreamTest) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
       "/api/mode": { POST: guarded(handleMode) },

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -912,6 +912,23 @@ button.ghost.danger:hover:not(:disabled) {
   accent-color: var(--primary);
 }
 
+/* How far along the run in flight is, when ComfyUI is counting steps. */
+.bar {
+  height: 0.375rem;
+  margin-top: var(--space-2xs);
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: var(--muted);
+}
+
+.bar > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--primary);
+  transition: width var(--dur-mid) var(--ease-out);
+}
+
 /* The child process's own words, so a wrong command explains itself. */
 .log {
   max-height: 14rem;

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -81,6 +81,60 @@ export async function sendHeartbeat(
   }
 }
 
+export type UpstreamTest = {
+  ok: boolean;
+  /** Round trip in milliseconds, however it ended. */
+  ms: number;
+  /** Jobs waiting for this host, when the server said. */
+  pendingJobs?: number;
+  /** Why it failed, as close to the server's own words as there are any. */
+  error?: string;
+};
+
+/** Enough of a rejection to tell a wrong secret from a wrong address. */
+const REASON_LIMIT = 120;
+
+/**
+ * One heartbeat, sent now, answering with why it failed rather than logging it.
+ *
+ * A separate call from {@link sendHeartbeat} on purpose: that one swallows
+ * failures because the poll loop must carry on regardless, and someone who has
+ * just typed a secret in wants the opposite — the status code, in the row.
+ */
+export async function testUpstream(
+  server: UpstreamServer,
+  status: ComfyStatusResult,
+): Promise<UpstreamTest> {
+  const started = Date.now();
+
+  try {
+    const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/heartbeat`, {
+      method: "POST",
+      headers: authHeaders(server),
+      body: JSON.stringify(status),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const ms = Date.now() - started;
+
+    if (!res.ok) {
+      const reason = (await res.text().catch(() => "")).trim().slice(0, REASON_LIMIT);
+      return {
+        ok: false,
+        ms,
+        error: reason ? `HTTP ${res.status} ${reason}` : `HTTP ${res.status}`,
+      };
+    }
+    const ack = (await res.json()) as HeartbeatAck;
+    return { ok: true, ms, pendingJobs: ack.pendingJobs };
+  } catch (err) {
+    return {
+      ok: false,
+      ms: Date.now() - started,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export async function claimJob(server: UpstreamServer): Promise<ClaimedJob | null> {
   try {
     const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/jobs/claim`, {


### PR DESCRIPTION
#4 と #5 の成果を `dev` に入れ直す PR です。レビュー済みのコードそのままで、新しい実装は含みません。

**何が起きたか。** #6 / #7 / #8 は stack で、#7 の base は `feat/3-accepting-schedule`、#8 の base は `feat/4-upstream-test` でした。GitHub が stacked PR の base を張り替えるのは、base ブランチがマージ時に**削除**されたときだけです。ブランチを残したままだったので、#7 のマージは upstream テストのコミットを（すでにマージ済みの）`feat/3-accepting-schedule` に入れ、#8 のマージは進捗表示のコミットを `feat/4-upstream-test` に入れました。`dev` に届いたのは #6 だけです。

つまり `dev` には `feat(servers)` と `feat(runs)` が入っていません。この PR がその2つを未変更のまま運びます（`c43c5da` と `17c370b`、rebase も修正もしていません）。

再発防止には、リポジトリ設定の **Automatically delete head branches** を有効にするのが早いです。base 削除が張り替えの引き金なので、次の stack は自動で `dev` まで上がります。有効にしない場合は、stack を下から順に一気にマージすれば同じ結果になります。

issue #4 と #5 はすでに閉じているので、この PR で開き直すことはしません。
