### PR TITLE
feat(servers): link a job server with a one-time code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ change something.
 - *ComfyUI* — where it is installed, and optionally the command to run there
 - *Process* — start and stop ComfyUI, with the tail of its output so a wrong
   command explains itself
-- *Upstream servers* — add, reorder and disable job servers. The order is the
-  priority
+- *Upstream servers* — link one with a code from its own UI, or fill a row in
+  by hand; reorder and disable them here too. The order is the priority
 
 **Generate** runs a workflow by hand: a form on one side, the run history on the
 other. Handy for checking a workflow does what you think before a job server
@@ -238,6 +238,17 @@ authenticated with `Authorization: Bearer <secret>`:
 | `POST /jobs/:id/result`    | the produced file, as the raw request body                   |
 | `POST /jobs/:id/complete`  | mark done                                                    |
 | `POST /jobs/:id/fail`      | mark failed, with `{ reason }`                               |
+
+A server may also implement one endpoint outside that block:
+
+| Endpoint                        | Purpose                                                   |
+| ------------------------------- | --------------------------------------------------------- |
+| `POST /api/internal/hosts/link` | trade `{ code }` for `{ hostId, hostSecret, hostName }`    |
+
+That is what *Link* on the Settings page calls. It is unauthenticated because
+the code is the credential: the server issues it, it works once, and it expires.
+A server without it is used the same way as before — fill the host id and secret
+in by hand.
 
 A claimed job looks like:
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -240,7 +240,29 @@ export async function reloadAgent(servers: UpstreamServer[]): Promise<void> {
   startAgent(servers);
 }
 
-/** Called after the Servers page saves, so a change takes effect at once. */
+/**
+ * Called after the Servers page saves, so a change takes effect at once.
+ *
+ * A running loop is handed the new list instead of being restarted. Restarting
+ * means waiting for the loop to leave the job it is in, which is up to
+ * `JOB_TIMEOUT_MS` of a page that looks hung — and nothing needs the wait:
+ * only starting a second loop alongside the first would double-claim, and
+ * swapping a list in place never does that. The job in flight finishes against
+ * the server it was claimed from, which it holds a reference to.
+ */
 export async function applyUpstreamChange(): Promise<void> {
-  await reloadAgent(activeUpstreams(await loadSettings()));
+  const servers = activeUpstreams(await loadSettings());
+
+  // Nothing is running, so there is no loop to hand it to.
+  if (!running) {
+    await reloadAgent(servers);
+    return;
+  }
+
+  upstreams = servers;
+  heartbeats.clear();
+
+  // Nothing left to claim from. Heartbeats stop now; the job in flight still
+  // reports back, because it carries its own server.
+  if (servers.length === 0) stopAgent();
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -140,7 +140,8 @@ function upstreamsFromEnv(): UpstreamConfig[] {
   return servers;
 }
 
-function hostFromUrl(url: string): string {
+/** The label a server gets when nobody named it: what its URL calls itself. */
+export function hostFromUrl(url: string): string {
   try {
     return new URL(url).host;
   } catch {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -134,6 +134,9 @@ const nodes = {
   workflowDir: el("workflow-dir"),
   servers: el("servers"),
   serversNote: el("servers-note"),
+  linkUrl: el<HTMLInputElement>("link-url"),
+  linkCode: el<HTMLInputElement>("link-code"),
+  linkNote: el("link-note"),
   jobs: el("jobs"),
   form: el<HTMLFormElement>("run-form"),
   select: el<HTMLSelectElement>("run-workflow"),
@@ -1165,6 +1168,33 @@ el("server-add").addEventListener("click", () => {
   ];
   serversDirty = true;
   if (latestState) renderServers(latestState);
+});
+
+/**
+ * The row is written on the server side, so what comes back is the truth and
+ * the editor is resynced onto it — including anything typed but not saved.
+ */
+el("server-link").addEventListener("click", async () => {
+  const url = nodes.linkUrl.value.trim();
+  const code = nodes.linkCode.value.trim();
+  if (!url || !code) {
+    setNote(nodes.linkNote, t("servers.linkNeeds"), true);
+    return;
+  }
+
+  setNote(nodes.linkNote, t("servers.linking"));
+  const result = await post<{ hostName: string | null }>("/api/link", { url, code });
+  if (!result.ok) {
+    setNote(nodes.linkNote, result.error ?? t("servers.linkFailed"), true);
+    return;
+  }
+
+  // Spent on use, so leaving it in the box would only invite a second try.
+  nodes.linkCode.value = "";
+  serversDirty = false;
+  const name = result.data?.hostName;
+  setNote(nodes.linkNote, name ? t("servers.linkedAs", { name }) : t("servers.linked"));
+  void poll();
 });
 
 nodes.servers.addEventListener("input", () => {

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -263,6 +263,27 @@ const STRINGS = {
     en: "Asked for work from the top down. The first server with something queued gets this machine, so the order is the priority.",
     ja: "上から順に問い合わせます。仕事を持っていた最初のサーバーがこのマシンを使うので、並び順がそのまま優先順位です。",
   },
+  "servers.link": { en: "Link", ja: "リンク" },
+  "servers.linkHelp": {
+    en: "Have a job server issue a link code, then paste it here with that server's URL. The code carries the credentials across, so there is nothing to copy by hand. Linking a server already in the list replaces its credentials.",
+    ja: "ジョブサーバー側でリンクコードを発行し、そのサーバーの URL と一緒に貼り付けてください。認証情報はコードが運ぶので、手で写すものはありません。すでに一覧にあるサーバーをリンクすると、その認証情報を置き換えます。",
+  },
+  "servers.linkUrl": { en: "Server URL", ja: "サーバー URL" },
+  "servers.linkCode": { en: "Link code", ja: "リンクコード" },
+  "servers.linkNeeds": {
+    en: "a URL and a code are both needed",
+    ja: "URL とコードの両方が必要です",
+  },
+  "servers.linking": { en: "linking…", ja: "リンク中…" },
+  "servers.linked": {
+    en: "linked — the agent picked it up",
+    ja: "リンクしました。エージェントに反映済みです",
+  },
+  "servers.linkedAs": {
+    en: "linked as {name} — the agent picked it up",
+    ja: "{name} としてリンクしました。エージェントに反映済みです",
+  },
+  "servers.linkFailed": { en: "linking failed", ja: "リンクできませんでした" },
   "servers.empty": {
     en: "No upstream servers. This machine runs whatever you queue here and nothing else.",
     ja: "上流サーバーはありません。このマシンはここで入れた分だけを実行します。",

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -405,6 +405,29 @@
               </button>
             </div>
             <p class="muted" data-i18n="servers.help"></p>
+            <div class="link">
+              <p class="muted" data-i18n="servers.linkHelp"></p>
+              <div class="row">
+                <label class="field">
+                  <span data-i18n="servers.linkUrl">Server URL</span>
+                  <input type="text" id="link-url" placeholder="https://queue.example.com" />
+                </label>
+                <label class="field">
+                  <span data-i18n="servers.linkCode">Link code</span>
+                  <input
+                    type="text"
+                    id="link-code"
+                    placeholder="XXXX-XXXX-XXXX"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                </label>
+              </div>
+              <div class="actions">
+                <button type="button" id="server-link" data-i18n="servers.link">Link</button>
+                <p class="muted" id="link-note"></p>
+              </div>
+            </div>
             <div id="servers"></div>
             <div class="actions">
               <button type="button" id="servers-save" data-i18n="servers.save">Save servers</button>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -13,7 +13,14 @@ import {
   startJob,
 } from "../jobs";
 import { latestProgress } from "../progress";
-import { RUN_MODES, loadSettings, newUpstreamId, publicUpstreams, saveSettings } from "../settings";
+import {
+  RUN_MODES,
+  hostFromUrl,
+  loadSettings,
+  newUpstreamId,
+  publicUpstreams,
+  saveSettings,
+} from "../settings";
 import { latestStatus, refreshStatus } from "../status";
 import {
   activeWorkflowName,
@@ -25,7 +32,7 @@ import {
   saveWorkflowFile,
   setActiveWorkflow,
 } from "../workflow";
-import { testUpstream } from "../upstream";
+import { claimLinkCode, testUpstream } from "../upstream";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -189,6 +196,62 @@ async function handleUpstreamTest(req: Request): Promise<Response> {
       { comfyStatus, queueRunning, queuePending },
     );
     return Response.json(result);
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * Link this machine to a job server with a one-time code issued by that
+ * server's own UI.
+ *
+ * The exchange happens here and not in the page for two reasons: the browser
+ * has no CORS grant from a job server it has never spoken to, and the secret
+ * that comes back has no business passing through the UI at all.
+ */
+async function handleLink(req: Request): Promise<Response> {
+  try {
+    const body = (await req.json()) as { url?: string; code?: string };
+    const url = (body.url ?? "").trim().replace(/\/$/, "");
+    const code = (body.code ?? "").trim();
+
+    if (!url) return fail("a server URL is required");
+    if (!/^https?:\/\//i.test(url))
+      return fail("the server URL must start with http:// or https://");
+    if (!code) return fail("a link code is required");
+
+    const linked = await claimLinkCode(url, code);
+
+    // One row per server URL. Linking the same server again replaces the
+    // credentials rather than leaving a second row claiming beside the first.
+    const settings = await loadSettings();
+    const known = settings.upstreams.some((server) => server.url === url);
+    const upstreams = known
+      ? settings.upstreams.map((server) =>
+          server.url === url
+            ? { ...server, hostId: linked.hostId, secret: linked.hostSecret }
+            : server,
+        )
+      : [
+          ...settings.upstreams,
+          {
+            id: newUpstreamId(),
+            name: hostFromUrl(url),
+            url,
+            hostId: linked.hostId,
+            secret: linked.hostSecret,
+            enabled: true,
+          },
+        ];
+
+    const saved = await saveSettings({ upstreams });
+    await applyUpstreamChange();
+
+    return Response.json({
+      upstreams: publicUpstreams(saved),
+      hostName: linked.hostName ?? null,
+      replaced: known,
+    });
   } catch (err) {
     return fail(err);
   }
@@ -503,6 +566,7 @@ export function startUi() {
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },
       "/api/upstreams/test": { POST: guarded(handleUpstreamTest) },
+      "/api/link": { POST: guarded(handleLink) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
       "/api/mode": { POST: guarded(handleMode) },

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -708,6 +708,12 @@ input[type="file"]::file-selector-button {
   cursor: pointer;
 }
 
+.link {
+  margin-bottom: var(--space-2xs);
+  padding-bottom: var(--space-2xs);
+  border-bottom: 1px solid var(--border);
+}
+
 .row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -14,6 +14,11 @@
  * - `POST /jobs/:jobId/result`        — upload the produced file as the raw body
  * - `POST /jobs/:jobId/complete`      — mark done
  * - `POST /jobs/:jobId/fail`          — mark failed with `{ reason }`
+ *
+ * Linking adds one more, outside the per-host block and unauthenticated
+ * because the code it takes is itself the credential:
+ *
+ * - `POST /api/internal/hosts/link`     — trade a one-time code for `{ hostId, hostSecret }`
  */
 
 import type { Settings, UpstreamConfig } from "./settings";
@@ -45,6 +50,42 @@ function toServer(config: UpstreamConfig): UpstreamServer {
     hostId: config.hostId,
     secret: config.secret,
   };
+}
+
+export type LinkedHost = {
+  hostId: string;
+  hostSecret: string;
+  /** What the server calls this host, so the UI can confirm what was linked. */
+  hostName?: string;
+};
+
+/**
+ * Trade a one-time code, issued by the job server's own UI, for this machine's
+ * credentials.
+ *
+ * This is the alternative to carrying a host id and a secret across by hand.
+ * The code is short-lived and spent on use, so it is safe to read off a screen
+ * in a way the secret it buys is not — which is why the secret is fetched here
+ * rather than shown to whoever is registering the machine.
+ */
+export async function claimLinkCode(url: string, code: string): Promise<LinkedHost> {
+  const res = await fetch(`${url}/api/internal/hosts/link`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `the server refused the code: HTTP ${res.status}`);
+  }
+
+  const linked = (await res.json()) as Partial<LinkedHost>;
+  if (!linked.hostId || !linked.hostSecret) {
+    throw new Error("the server accepted the code but sent no credentials");
+  }
+  return { hostId: linked.hostId, hostSecret: linked.hostSecret, hostName: linked.hostName };
 }
 
 function authHeaders(server: UpstreamServer): Record<string, string> {


### PR DESCRIPTION
Closes #14.

ジョブサーバー側で発行したワンタイムコードで、このマシンを登録できるようにします。設定ページの *Upstream servers* にサーバー URL とリンクコードの欄が増え、*Link* を押すと認証情報が入った行がそのまま出来上がります。ホスト ID とシークレットを手で写す作業がなくなります。

**作り**

- 交換はアプリのサーバー側で行います（`POST /api/link` → ジョブサーバーの `POST /api/internal/hosts/link`）。初めて話すジョブサーバーにブラウザからは CORS 許可がなく、返ってくるシークレットを UI に通す理由もないためです。
- 行はサーバー URL 単位です。同じサーバーをもう一度リンクすると、行を増やさず認証情報を差し替えます（レスポンスの `replaced` で区別できます）。
- 登録後に `applyUpstreamChange()` を呼ぶので、保存を待たずにエージェントが拾います。
- コードは使い捨てなので、成功したら入力欄を空にします。
- このエンドポイントを持たないジョブサーバーは、これまでどおり手入力の行で使えます。README にプロトコルの追記があります。

**2つ目のコミット（`fix(agent)`）について**

`applyUpstreamChange()` はこれまでエージェントを停止 → 再起動していました。停止は実行中のジョブが終わるまで待つため、ジョブ実行中にリンクすると最大 `JOB_TIMEOUT_MS` のあいだ画面が固まります。二重に claim する原因はループが2本になることだけなので、走っているループには一覧を差し替えるだけにしました。実行中のジョブは claim 元のサーバー参照を自分で持っているので、そのまま完了報告まで到達します。

**確認したこと**

ダミーのジョブサーバー（コードは1回だけ有効）を立てて、アプリのサーバー経由で確認しました。

- URL なし / スキームなし → それぞれの理由を返す
- 誤ったコード → サーバーの文言をそのまま返す（`unknown or expired code`）
- 正しいコード → 行が作られ、`hostName` が返り、`hasSecret: true`。API レスポンスにシークレットは含まれない
- 使用済みコードの再利用 → `that code has been used`
- リンク直後に `[heartbeat] 127.0.0.1:3943 OK` が出る（エージェントが即座に拾っている）
- 同じ URL で再リンク → `replaced: true`、行は1本のまま

`bun run check:ci` と `tsc --noEmit` も通っています。

**#13 との衝突は解消済みです**

#12 と #13 のマージ後の `dev` に rebase しました。衝突したのは `src/ui/app.ts` と `src/ui/server.ts` の3か所です。

- `post<T>()` の一般化 — 両方が同じ変更を持っていたので、先に `dev` に入っている側を残しました（`as { error?: string } & T`）。
- `src/ui/server.ts` の import — `hostFromUrl` を含む settings のブロックと `latestProgress` を併存させ、`../upstream` からの2本（`claimLinkCode` と `testUpstream`）を1本にまとめました。
- ハンドラと route 表 — `handleUpstreamTest` と `handleLink`、`/api/upstreams/test` と `/api/link` を両方残しました。

統合後のコードで再確認しています。

- リンク成功 → 行が作られ `hostName: studio-rig`、`hasSecret: true`
- リンクした行に対して *Test*（シークレット欄は空 = 保存済みを使用）→ `ok: true`
- 誤ったシークレットを打った状態で *Test* → `HTTP 401 bad secret`
- `/api/state` の `progress` と `accepting` は従来どおり
- リンク直後にハートビートが1回出る

`tsc --noEmit` と `bun run check:ci` も通っています。
