### PR TITLE
ci: switch close-issues to pull_request so merging into dev fires it

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -5,19 +5,25 @@ name: Close issues
 # rather than work. Every pull request here lands on `dev`, so this does what
 # GitHub would have done if `dev` were the default.
 #
-# `pull_request_target`, not `pull_request`: a pull request from a fork gets a
-# read-only token, which cannot close anything. Nothing from the pull request is
-# checked out or run here, so running in the base context brings no risk.
+# `pull_request`, not `pull_request_target`: the target event takes its
+# workflow file from the default branch, and this file lives only on `dev`, so
+# as a target workflow it never fired. The plain event reads the file from the
+# pull request's merge result, which has it as soon as `dev` does. The price is
+# pull requests from forks — their read-only token cannot close anything — and
+# the `if` below skips those rather than failing them.
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
     branches: [dev]
 
 jobs:
   close:
     name: Close what it answers
-    # Closing a pull request without merging it answers nothing.
-    if: github.event.pull_request.merged == true
+    # Closing a pull request without merging it answers nothing, and a fork's
+    # read-only token could not close anything anyway.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
Closes #16.

#12 で入れた *Close issues* ワークフローは一度も動いていませんでした。`pull_request_target` はデフォルトブランチ(`main`)にあるワークフローファイルを使うイベントで、このファイルは `dev` にしかないため、イベント自体が発火しません。実際、Actions のワークフロー一覧に登録されているのは CI と Release だけで、`pull_request_target` の実行は 0 件、#15 の `Closes #14` も効かず #14 は手で閉じられています。

**変更点**

- トリガーを `pull_request`(types: closed, branches: dev)に変更。こちらは PR のマージ結果からファイルを読むので、この PR が `dev` に入った時点から効きます。
- fork からの PR は job の `if` でスキップ。`pull_request` では fork の token が読み取り専用で issue を閉じられないためです(`pull_request_target` を選んだ元の理由がこれでしたが、動かないトリガーでは意味がないので、fork はスキップに倒しました)。head リポジトリが削除済みの場合も `head.repo.full_name` が null になり同じくスキップされます。
- 本文のパースと issue を閉じるスクリプト部分は無変更です。

**確認したこと**

- YAML がパースできること(トリガーと `if` の値も確認)。
- `branches: [dev]` は base ブランチで絞るので、stacked PR(base が別のフィーチャーブランチ)では動かず、`dev` へのマージでだけ動くこと。CI の `pull_request` トリガーは types 未指定(opened / synchronize / reopened)なので、closed で CI が余計に走ることもありません。

トリガー自体はマージされるまで試せないので、この PR のマージで #16 が自動で閉じるかどうかがそのまま動作確認になります。