### PR TITLE
feat(ui): split the settings page into tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,23 @@ If you would rather not trust a binary at all, it runs from source — see
 
 ## The window
 
-Two pages, because most of the time the app is left alone and only visited to
-change something.
+One tab per subject, so the thing you came to change is a click away rather
+than somewhere down a long page.
 
-**Settings** is where it opens.
+**Workflows** is where it opens: add a workflow, see what each one exposes,
+choose the one used for jobs that do not name one, delete the ones you are
+done with.
 
-- *Upload* / *Installed* — add a workflow, see what each one exposes, choose the
-  one used for jobs that do not name one, delete the ones you are done with
-- *ComfyUI* — where it is installed, and optionally the command to run there
-- *Process* — start and stop ComfyUI, with the tail of its output so a wrong
-  command explains itself
-- *Upstream servers* — link one with a code from its own UI, or fill a row in
-  by hand; reorder and disable them here too. The order is the priority
+**ComfyUI** points the app at your install — where it is, and optionally the
+command to run there — and starts and stops it, with the tail of its output so
+a wrong command explains itself.
+
+**Servers** attaches job servers: link one with a code from its own UI, or fill
+a row in by hand; reorder and disable them here too. The order is the priority.
+
+**Accepting** says when job servers get work out of this machine — a hold for
+the next while, or a daily window. [When it accepts](#when-it-accepts) has the
+details.
 
 **Generate** runs a workflow by hand: a form on one side, the run history on the
 other. Handy for checking a workflow does what you think before a job server
@@ -81,7 +86,7 @@ starts sending work.
 A run in flight carries a bar — the steps ComfyUI has done out of the steps it
 expects, and the node it is on — so a slow workflow can be told from a stuck one.
 Jobs claimed from a job server land in the same history, so they get the same
-bar, and the status bar carries the percentage on either page.
+bar, and the status bar carries the percentage on every page.
 
 The header switches the theme and the language, and the button beside them opens
 the app's own settings — the same switches the tray menu carries.
@@ -113,8 +118,7 @@ The same three are in the tray, so it can be changed with the window closed.
 
 ### When it accepts
 
-*Accepting* does not have to mean right now. Under *Accepting jobs* on the
-Settings page:
+*Accepting* does not have to mean right now. On the Accepting page:
 
 - **Hold off for** 15, 30 or 60 minutes. The machine stops taking jobs and
   starts again on its own, which is what you want when the GPU is yours for the
@@ -151,7 +155,7 @@ Both are stored with everything else, so the tray and the page always agree.
 
 ## Pointing it at ComfyUI
 
-On the Settings page, put the folder in *Directory*:
+On the ComfyUI page, put the folder in *Directory*:
 
 | What you installed | What to enter | What gets run |
 | ------------------ | ------------- | ------------- |
@@ -169,7 +173,7 @@ launched can be stopped from the app.
 ## Bring your own workflow
 
 In ComfyUI, turn on **Settings → Lite Graph → Enable Dev mode options**, then
-use **Workflow → Export (API)**. Upload the JSON on the Settings page.
+use **Workflow → Export (API)**. Upload the JSON on the Workflows page.
 
 ComfyUI's API format is a flat map of node id to node, and each node records its
 class and how its inputs are wired. That is enough to find the interesting
@@ -184,7 +188,7 @@ inputs without being told:
 | `length`    | a node with a numeric `length` input (frame count on video workflows) |
 | `frameRate` | a node with a numeric `frame_rate` input                              |
 
-The Settings page shows which of these were found, so a workflow that needs help
+The Workflows page shows which of these were found, so a workflow that needs help
 is obvious before you run it. Anything not found is simply not offered — a
 workflow with no `LoadImage` gets no image field.
 
@@ -210,7 +214,7 @@ reported in the UI rather than silently ignored.
 
 ## Attaching a job server
 
-Left alone, the app runs standalone. Add a server on the Settings page and it
+Left alone, the app runs standalone. Add a server on the Servers page and it
 also polls for queued jobs, runs them through the active workflow and uploads
 the result — which is the point of the tray: the machine keeps serving with
 nothing on screen.
@@ -245,7 +249,7 @@ A server may also implement one endpoint outside that block:
 | ------------------------------- | --------------------------------------------------------- |
 | `POST /api/internal/hosts/link` | trade `{ code }` for `{ hostId, hostSecret, hostName }`    |
 
-That is what *Link* on the Settings page calls. It is unauthenticated because
+That is what *Link* on the Servers page calls. It is unauthenticated because
 the code is the credential: the server issues it, it works once, and it expires.
 A server without it is used the same way as before — fill the host id and secret
 in by hand.

--- a/src/comfy-process.ts
+++ b/src/comfy-process.ts
@@ -104,7 +104,7 @@ export async function startComfy(): Promise<void> {
 
   const settings = await loadSettings();
   if (!settings.comfyDir) {
-    throw new Error("set the ComfyUI directory on the Settings page first");
+    throw new Error("set the ComfyUI directory on the ComfyUI page first");
   }
   if (!existsSync(settings.comfyDir)) {
     throw new Error(`no such directory: ${settings.comfyDir}`);

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -115,7 +115,7 @@ type State = {
 };
 
 const POLL_MS = 2000;
-const PAGES = ["settings", "generate"] as const;
+const PAGES = ["workflows", "comfyui", "servers", "accepting", "generate"] as const;
 type Page = (typeof PAGES)[number];
 
 function el<T extends HTMLElement>(id: string): T {
@@ -288,10 +288,13 @@ function setNote(target: HTMLElement, text: string, isError = false): void {
 // Pages
 // ---------------------------------------------------------------------------
 
-/** Settings is the landing page; running a workflow by hand is the sideline. */
+/**
+ * Workflows is the landing tab; running a workflow by hand is the sideline.
+ * Any hash naming no tab lands there too — the old `#/settings` included.
+ */
 function currentPage(): Page {
   const hash = location.hash.replace(/^#\/?/, "");
-  return (PAGES as readonly string[]).includes(hash) ? (hash as Page) : "settings";
+  return (PAGES as readonly string[]).includes(hash) ? (hash as Page) : "workflows";
 }
 
 function showPage(): void {

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -117,7 +117,10 @@ const STRINGS = {
   "desktop.saveFailed": { en: "save failed", ja: "保存できませんでした" },
 
   "nav.label": { en: "Sections", ja: "セクション" },
-  "nav.settings": { en: "Settings", ja: "設定" },
+  "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
+  "nav.comfyui": { en: "ComfyUI", ja: "ComfyUI" },
+  "nav.servers": { en: "Servers", ja: "サーバー" },
+  "nav.accepting": { en: "Accepting", ja: "ジョブ受付" },
   "nav.generate": { en: "Generate", ja: "生成" },
 
   // Status chips ------------------------------------------------------------
@@ -241,8 +244,8 @@ const STRINGS = {
   "comfy.start": { en: "Start ComfyUI", ja: "ComfyUI を起動" },
   "comfy.stop": { en: "Stop ComfyUI", ja: "ComfyUI を停止" },
   "comfy.needsDir": {
-    en: "set the ComfyUI directory on the Settings page first",
-    ja: "先に設定ページで ComfyUI のディレクトリを指定してください",
+    en: "set the ComfyUI directory on the ComfyUI page first",
+    ja: "先に ComfyUI ページでディレクトリを指定してください",
   },
 
   "process.title": { en: "Process", ja: "プロセス" },

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -234,10 +234,20 @@
     <div class="statusbar" id="vitals"></div>
 
     <div class="shell">
-      <!-- Navigation only. Actions and settings live on the pages themselves. -->
+      <!-- Navigation only. Actions and settings live on the pages themselves.
+           One tab per subject, so a page fits on screen instead of scrolling. -->
       <nav class="sidebar" data-i18n-label="nav.label">
-        <a class="nav-item" href="#/settings" data-page-link="settings" data-i18n="nav.settings"
-          >Settings</a
+        <a class="nav-item" href="#/workflows" data-page-link="workflows" data-i18n="nav.workflows"
+          >Workflows</a
+        >
+        <a class="nav-item" href="#/comfyui" data-page-link="comfyui" data-i18n="nav.comfyui"
+          >ComfyUI</a
+        >
+        <a class="nav-item" href="#/servers" data-page-link="servers" data-i18n="nav.servers"
+          >Servers</a
+        >
+        <a class="nav-item" href="#/accepting" data-page-link="accepting" data-i18n="nav.accepting"
+          >Accepting</a
         >
         <a class="nav-item" href="#/generate" data-page-link="generate" data-i18n="nav.generate"
           >Generate</a
@@ -327,7 +337,7 @@
           </div>
         </section>
 
-        <section class="page" data-page="settings">
+        <section class="page" data-page="workflows">
           <section class="panel">
             <div class="panel-head">
               <h2 data-i18n="upload.title">Upload</h2>
@@ -365,7 +375,9 @@
             <div class="panel-head"><h2 data-i18n="workflows.title">Installed</h2></div>
             <div id="workflows"></div>
           </section>
+        </section>
 
+        <section class="page" data-page="comfyui" hidden>
           <section class="panel">
             <div class="panel-head"><h2 data-i18n="comfy.title">ComfyUI</h2></div>
             <form id="settings-form">
@@ -396,7 +408,9 @@
             </div>
             <div id="comfy-process"></div>
           </section>
+        </section>
 
+        <section class="page" data-page="servers" hidden>
           <section class="panel">
             <div class="panel-head">
               <h2 data-i18n="servers.title">Upstream servers</h2>
@@ -437,11 +451,13 @@
               <p class="muted" id="servers-note"></p>
             </div>
           </section>
+        </section>
 
-          <!-- The mode in the header says whether this machine takes work at
-               all. This says when, so nobody has to be sitting here to switch
-               it back. Both only ever hold jobs back — a run started here, and
-               ComfyUI itself, are untouched. -->
+        <!-- The mode in the header says whether this machine takes work at
+             all. This says when, so nobody has to be sitting here to switch
+             it back. Both only ever hold jobs back — a run started here, and
+             ComfyUI itself, are untouched. -->
+        <section class="page" data-page="accepting" hidden>
           <section class="panel">
             <div class="panel-head"><h2 data-i18n="accept.title">Accepting jobs</h2></div>
             <p class="muted" data-i18n="accept.help"></p>


### PR DESCRIPTION
Closes #18.

Settings ページに 6 枚のパネルが縦積みで、目的の設定までのスクロールが長かったので、役割ごとの 4 タブに分割しました。Generate と合わせてサイドバーは 5 タブになります。

- **Workflows** — Upload + Installed
- **ComfyUI** — ComfyUI(ディレクトリ / 起動コマンド)+ Process
- **Servers** — Upstream servers(リンク + 一覧)
- **Accepting** — Accepting jobs(一時停止 + 時間帯)

**作り**

- 既存のハッシュルーティング(`PAGES` + `data-page` + `data-page-link`)をそのまま使っています。増えたのはページ定義だけで、切り替えの仕組みに変更はありません。
- 着地タブは Workflows(旧 Settings の先頭パネルと同じ)。未知のハッシュ — 旧 `#/settings` を含む — も Workflows に落ちます。
- 「Settings ページ」を指していた文言も追従させました: README の 6 箇所と概要(「Two pages」の段落)、`comfy.needsDir`(en/ja)、`comfy-process.ts` のエラーメッセージ。
- `workflows.empty` の「上からアップロード」や `process.noDir` の「上の欄に入力」は、参照先のパネルが同じタブ内に残るのでそのまま正しく読めます。

**確認したこと**

- `bun run check:ci` と `tsc --noEmit` が通ること。
- HTML をパースして、5 ページ / 5 リンクが揃い、各パネルが意図したページに入っていること(初期表示は Workflows のみ、他は `hidden`)。
- `data-i18n` 系のキーがすべて `i18n.ts` に存在すること。
- `bun run src/index.ts` で起動し、新しいマークアップが配信されること。