### PR TITLE
feat(status): show GPU VRAM in the status bar

### DIFF
--- a/src/comfy.ts
+++ b/src/comfy.ts
@@ -1,13 +1,36 @@
 import { CLIENT_ID } from "./progress";
 import type { ApiWorkflow } from "./slots";
-import type { ComfyStatusResult, OutputKind, RunOutput } from "./types";
+import type { ComfyStatusResult, GpuStatus, OutputKind, RunOutput } from "./types";
 
 type ComfyQueueResponse = {
   queue_running?: unknown[];
   queue_pending?: unknown[];
 };
 
-/** Reachability plus queue depth, used for heartbeats and the UI header. */
+type SystemStats = {
+  devices?: {
+    name?: string;
+    type?: string;
+    vram_total?: number;
+    vram_free?: number;
+  }[];
+};
+
+/** The first device that is not the CPU — the one the models actually load on. */
+function firstGpu(stats: SystemStats): GpuStatus | null {
+  const device = stats.devices?.find((entry) => entry.type !== "cpu");
+  if (
+    !device ||
+    typeof device.vram_total !== "number" ||
+    typeof device.vram_free !== "number" ||
+    device.vram_total <= 0
+  ) {
+    return null;
+  }
+  return { name: device.name ?? "GPU", vramTotal: device.vram_total, vramFree: device.vram_free };
+}
+
+/** Reachability, queue depth and VRAM, used for heartbeats and the UI header. */
 export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
   try {
     const signal = AbortSignal.timeout(5000);
@@ -17,9 +40,10 @@ export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
     ]);
 
     if (!statsRes.ok || !queueRes.ok) {
-      return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0 };
+      return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0, gpu: null };
     }
 
+    const stats = (await statsRes.json()) as SystemStats;
     const queue = (await queueRes.json()) as ComfyQueueResponse;
     const queueRunning = queue.queue_running?.length ?? 0;
     const queuePending = queue.queue_pending?.length ?? 0;
@@ -28,9 +52,10 @@ export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
       comfyStatus: queueRunning > 0 ? "busy" : "available",
       queueRunning,
       queuePending,
+      gpu: firstGpu(stats),
     };
   } catch {
-    return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0 };
+    return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0, gpu: null };
   }
 }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -10,6 +10,7 @@ let latest: ComfyStatusResult = {
   comfyStatus: "unavailable",
   queueRunning: 0,
   queuePending: 0,
+  gpu: null,
 };
 let checkedAt = 0;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,22 @@
 export type ComfyStatus = "available" | "busy" | "unavailable";
 
+/**
+ * The GPU as ComfyUI reports it, in bytes. Read through ComfyUI rather than
+ * from this machine, so a remote `COMFY_URL` shows the GPU actually doing the
+ * work.
+ */
+export type GpuStatus = {
+  name: string;
+  vramTotal: number;
+  vramFree: number;
+};
+
 export type ComfyStatusResult = {
   comfyStatus: ComfyStatus;
   queueRunning: number;
   queuePending: number;
+  /** `null` when ComfyUI is unreachable or reported no GPU device. */
+  gpu: GpuStatus | null;
 };
 
 export type OutputKind = "image" | "video" | "audio" | "file";

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -69,6 +69,8 @@ type State = {
     comfyStatus: "available" | "busy" | "unavailable";
     queueRunning: number;
     queuePending: number;
+    /** VRAM in bytes, as ComfyUI reports its GPU; null without one. */
+    gpu: { name: string; vramTotal: number; vramFree: number } | null;
     checkedAt: number;
   };
   comfyProcess: {
@@ -196,6 +198,11 @@ function formatTime(ms: number): string {
 /** Whole percent, clamped — a step past the max would otherwise overflow the bar. */
 function progressPercent(progress: { value: number; max: number }): number {
   return Math.min(100, Math.max(0, Math.round((progress.value / progress.max) * 100)));
+}
+
+/** Bytes as gigabytes with one decimal, the unit VRAM is talked about in. */
+function gb(bytes: number): string {
+  return (bytes / 1024 ** 3).toFixed(1);
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -347,11 +354,27 @@ function renderVitals(state: State): void {
     chip(t("vitals.comfy"), esc(comfyStatusLabel(comfy.comfyStatus)), tone),
     chip(t("vitals.running"), pad(comfy.queueRunning)),
     chip(t("vitals.pending"), pad(comfy.queuePending)),
+  ];
+
+  // The GPU is what this machine lends out, so its headroom belongs up here.
+  // The dot only appears when the free VRAM is running out.
+  if (comfy.gpu) {
+    const low = comfy.gpu.vramFree / comfy.gpu.vramTotal < 0.1;
+    chips.push(
+      chip(
+        t("vitals.vram"),
+        `${gb(comfy.gpu.vramTotal - comfy.gpu.vramFree)}/${gb(comfy.gpu.vramTotal)} GB`,
+        low ? "warn" : undefined,
+      ),
+    );
+  }
+
+  chips.push(
     total === 0
       ? chip(t("vitals.agent"), t("vitals.standalone"))
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
     chip(t("vitals.work"), work.label, work.tone),
-  ];
+  );
 
   if (state.progress && state.progress.max > 0) {
     chips.push(chip(t("vitals.progress"), `${progressPercent(state.progress)}%`, "run"));

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -132,6 +132,7 @@ const STRINGS = {
   "vitals.process": { en: "process", ja: "プロセス" },
   "vitals.access": { en: "access", ja: "アクセス" },
   "vitals.work": { en: "work", ja: "受付" },
+  "vitals.vram": { en: "VRAM", ja: "VRAM" },
   "vitals.progress": { en: "progress", ja: "進捗" },
   "vitals.tokenNeeded": {
     en: "open this page as ?token=<UI_TOKEN>",

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -190,10 +190,10 @@ async function handleUpstreamTest(req: Request): Promise<Response> {
     const secret = (input.secret ?? "").trim() || stored?.secret || "";
     if (!secret) return fail("a secret is needed");
 
-    const { comfyStatus, queueRunning, queuePending } = latestStatus();
+    const { comfyStatus, queueRunning, queuePending, gpu } = latestStatus();
     const result = await testUpstream(
       { name: url, url, hostId, secret },
-      { comfyStatus, queueRunning, queuePending },
+      { comfyStatus, queueRunning, queuePending, gpu },
     );
     return Response.json(result);
   } catch (err) {


### PR DESCRIPTION
Closes #21. #27(watchdog)の上に積んだスタック PR です(2/7)。

GPU を貸す道具なのに GPU の状態がどこにも出ていなかったので、ステータスバーに VRAM チップ(使用量 / 合計 GB)を追加しました。

**作り**

- ComfyUI の `/system_stats` は既に叩いていてボディを捨てていたので、追加リクエストなしで `devices` から CPU 以外の最初のデバイスの `vram_total` / `vram_free` を拾います。ComfyUI 経由なので `COMFY_URL` がリモートでも実際に仕事をする GPU の値になります。
- `ComfyStatusResult` に `gpu`(バイト単位、GPU なし・到達不能なら `null`)を追加。ハートビートのボディにもそのまま載ります(上流は未知フィールドを無視する想定。ゆくゆくはジョブサーバー側で使えます)。
- チップは GPU があるときだけ表示。空き VRAM が 10% を切ったときだけ warn のドットを出します(普段はドットなし)。

**確認したこと**

- モック ComfyUI(RTX 4090 相当の `/system_stats`)を立てた統合テストで、`/api/state` の `comfy.gpu` が期待値になり、表示は「5.2/24.0 GB」になること。
- `bun run check:ci` と `tsc --noEmit`。