### PR TITLE
feat(notify): desktop notifications for failures

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -8,6 +8,7 @@ import {
   POLL_INTERVAL_MS,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./config";
+import { pushEvent } from "./events";
 import { completeJob, failJob, markQueued, startJob } from "./jobs";
 import { latestStatus, refreshStatus } from "./status";
 import { RESTART_EXIT_CODE, remoteHasUpdate } from "./updater";
@@ -60,12 +61,17 @@ async function sendHeartbeats() {
 
   await Promise.all(
     upstreams.map(async (server) => {
+      // What the last beat said, so only a change of state is announced.
+      const was = heartbeats.get(server.name)?.ok;
+
       const ack = await sendHeartbeat(server, status);
       if (!ack) {
         heartbeats.set(server.name, { ok: false, at: Date.now() });
+        if (was !== false) pushEvent("upstream-down", { server: server.name });
         return;
       }
       heartbeats.set(server.name, { ok: true, at: Date.now(), pendingJobs: ack.pendingJobs });
+      if (was === false) pushEvent("upstream-up", { server: server.name });
       const backlog =
         ack.pendingJobs === undefined ? "" : ` | upstream queue: ${ack.pendingJobs} waiting`;
       console.log(

--- a/src/comfy-process.ts
+++ b/src/comfy-process.ts
@@ -19,6 +19,7 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { pushEvent } from "./events";
 import { loadSettings } from "./settings";
 
 export type ComfyProcessState = {
@@ -182,10 +183,12 @@ function maybeRestart(uptimeMs: number): void {
     wanted = false;
     lastError = "ComfyUI keeps crashing right after starting — not restarting, check the log";
     note(`— ${lastError}`);
+    pushEvent("comfy-gave-up");
     return;
   }
 
   note(`— restarting in ${RESTART_DELAY_MS / 1000} s (crash ${fastFails}/${MAX_FAST_FAILS})`);
+  pushEvent("comfy-crashed");
   restartTimer = setTimeout(() => {
     restartTimer = null;
     void restart();

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,41 @@
+/**
+ * Things worth telling a person about, kept as a small ring the UI reads from
+ * `/api/state` and turns into OS notifications.
+ *
+ * The server records facts — kind and parameters — and whoever displays them
+ * writes the sentence, in the reader's language. Ids are time-based so a
+ * watcher's "seen up to here" survives this process restarting; the ring is
+ * short because anything older is history, and history is what the log and the
+ * Runs page are for.
+ */
+
+export type UiEventKind =
+  | "job-failed"
+  | "upstream-down"
+  | "upstream-up"
+  | "comfy-crashed"
+  | "comfy-gave-up";
+
+export type UiEvent = {
+  id: number;
+  at: number;
+  kind: UiEventKind;
+  /** What the event is about — workflow, server name, error — for the message. */
+  params: Record<string, string>;
+};
+
+const MAX_EVENTS = 20;
+
+const events: UiEvent[] = [];
+let nextId = 0;
+
+export function pushEvent(kind: UiEventKind, params: Record<string, string> = {}): void {
+  // Monotonic and larger than any id a previous run handed out.
+  nextId = Math.max(nextId + 1, Date.now());
+  events.push({ id: nextId, at: Date.now(), kind, params });
+  if (events.length > MAX_EVENTS) events.splice(0, events.length - MAX_EVENTS);
+}
+
+export function listEvents(): UiEvent[] {
+  return events;
+}

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -9,6 +9,7 @@
 
 import { readFile, writeFile } from "node:fs/promises";
 import { JOBS_FILE } from "./config";
+import { pushEvent } from "./events";
 import type { JobRecord, JobSource, RunOutput } from "./types";
 
 const MAX_JOBS = 200;
@@ -83,6 +84,8 @@ export function failJob(job: JobRecord, error: string): void {
   job.error = error;
   job.finishedAt = Date.now();
   persist();
+  // Cut for a notification body, not for the record: `job.error` keeps it all.
+  pushEvent("job-failed", { workflow: job.workflow, error: error.slice(0, 200) });
 }
 
 export function listJobs(): JobRecord[] {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -7,7 +7,7 @@
  * into is left alone until they save or revert.
  */
 
-import { LANGS, lang, locale, onLangChange, setLang, t } from "./i18n";
+import { LANGS, isKey, lang, locale, onLangChange, setLang, t } from "./i18n";
 import type { Key, Lang } from "./i18n";
 
 type RunMode = "accepting" | "local" | "paused";
@@ -114,6 +114,8 @@ type State = {
   } | null;
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
+  /** Ring of recent server-side events, oldest first; ids only ever grow. */
+  events: { id: number; at: number; kind: string; params: Record<string, string> }[];
 };
 
 const POLL_MS = 2000;
@@ -170,6 +172,8 @@ const nodes = {
   acceptNote: el("accept-note"),
   desktopAutostart: el<HTMLInputElement>("desktop-autostart"),
   desktopNote: el("desktop-note"),
+  notifyEnabled: el<HTMLInputElement>("notify-enabled"),
+  notifyNote: el("notify-note"),
 };
 
 function esc(value: unknown): string {
@@ -776,7 +780,10 @@ function openPopover(target: Popover | null): void {
     popover.panel.hidden = !open;
     popover.button.setAttribute("aria-expanded", String(open));
   }
-  if (target !== DESKTOP_POPOVER) setNote(nodes.desktopNote, "");
+  if (target !== DESKTOP_POPOVER) {
+    setNote(nodes.desktopNote, "");
+    setNote(nodes.notifyNote, "");
+  }
   if (target !== MODE_POPOVER) setNote(nodes.modeNote, "");
 }
 
@@ -901,6 +908,111 @@ async function saveDesktop(path: string, body: unknown): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Notifications — server-side events turned into OS notifications
+// ---------------------------------------------------------------------------
+
+const NOTIFY_KEY = "notify";
+const NOTIFY_SEEN_KEY = "notify-seen";
+
+function notifyOn(): boolean {
+  try {
+    return localStorage.getItem(NOTIFY_KEY) === "on";
+  } catch {
+    return false;
+  }
+}
+
+function storeNotify(on: boolean): void {
+  try {
+    localStorage.setItem(NOTIFY_KEY, on ? "on" : "off");
+  } catch {
+    // Private mode — the choice lasts for this tab only.
+  }
+}
+
+let notifySeen = (() => {
+  try {
+    return Number(localStorage.getItem(NOTIFY_SEEN_KEY) ?? "0") || 0;
+  } catch {
+    return 0;
+  }
+})();
+
+/** False until the first poll: its backlog predates this page, so it is noise. */
+let notifyPrimed = false;
+
+function rememberSeen(id: number): void {
+  notifySeen = id;
+  try {
+    localStorage.setItem(NOTIFY_SEEN_KEY, String(id));
+  } catch {
+    // Private mode — an old event may notify again after a reload.
+  }
+}
+
+function notifyGranted(): boolean {
+  return "Notification" in window && Notification.permission === "granted";
+}
+
+function syncNotify(state: State): void {
+  const newest = state.events.at(-1)?.id ?? 0;
+
+  if (!notifyPrimed) {
+    notifyPrimed = true;
+    if (newest > notifySeen) rememberSeen(newest);
+    return;
+  }
+  if (newest <= notifySeen) return;
+
+  const fresh = state.events.filter((event) => event.id > notifySeen);
+  // Advanced even while notifications are off, so turning them on later does
+  // not replay history.
+  rememberSeen(newest);
+  if (!notifyOn() || !notifyGranted()) return;
+
+  for (const event of fresh) {
+    const key = `notify.${event.kind}`;
+    // A kind this page has no words for is skipped rather than crashed on —
+    // the server can be newer than a cached page.
+    if (!isKey(key)) continue;
+    try {
+      new Notification(t(key, event.params), {
+        body: event.params["error"] ?? "",
+        tag: `dcs-${event.id}`,
+      });
+    } catch {
+      // The permission can be revoked between polls; nothing to be done.
+    }
+  }
+}
+
+/**
+ * Turning it on asks the browser there and then, so the permission prompt is
+ * the answer to a click rather than appearing out of nowhere.
+ */
+async function setNotify(on: boolean): Promise<void> {
+  if (!on) {
+    storeNotify(false);
+    setNote(nodes.notifyNote, "");
+    return;
+  }
+  if (!("Notification" in window)) {
+    nodes.notifyEnabled.checked = false;
+    setNote(nodes.notifyNote, t("notify.unsupported"), true);
+    return;
+  }
+  const permission =
+    Notification.permission === "granted" ? "granted" : await Notification.requestPermission();
+  if (permission !== "granted") {
+    nodes.notifyEnabled.checked = false;
+    setNote(nodes.notifyNote, t("notify.blocked"), true);
+    return;
+  }
+  storeNotify(true);
+  setNote(nodes.notifyNote, "");
+}
+
+// ---------------------------------------------------------------------------
 // Run form
 // ---------------------------------------------------------------------------
 
@@ -970,6 +1082,7 @@ function render(state: State): void {
   syncMode(state);
   syncAccepting(state);
   syncDesktop(state);
+  syncNotify(state);
   syncForm(state);
 }
 
@@ -1385,6 +1498,8 @@ nodes.desktopAutostart.addEventListener("change", () => {
   void saveDesktop("/api/desktop", { autostart: nodes.desktopAutostart.checked });
 });
 
+nodes.notifyEnabled.addEventListener("change", () => void setNotify(nodes.notifyEnabled.checked));
+
 nodes.desktopPanel.addEventListener("click", (event) => {
   const choice = (event.target as HTMLElement).closest<HTMLElement>("[data-close-action]")?.dataset[
     "closeAction"
@@ -1423,6 +1538,9 @@ setInterval(() => {
     if (Number.isFinite(started)) span.textContent = formatDuration(Date.now() - started);
   }
 }, 1000);
+
+// A permission revoked since last time reads as "off", matching what happens.
+nodes.notifyEnabled.checked = notifyOn() && notifyGranted();
 
 applyTheme(currentTheme());
 setLang(lang());

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -116,6 +116,35 @@ const STRINGS = {
   "desktop.saved": { en: "saved", ja: "保存しました" },
   "desktop.saveFailed": { en: "save failed", ja: "保存できませんでした" },
 
+  // Notifications — the sentence for each event kind the server records ------
+  "notify.label": { en: "Notifications", ja: "通知" },
+  "notify.enable": { en: "Notify about failures", ja: "失敗や切断を通知する" },
+  "notify.unsupported": {
+    en: "this browser cannot show notifications",
+    ja: "このブラウザは通知に対応していません",
+  },
+  "notify.blocked": {
+    en: "the browser refused — allow notifications for this site",
+    ja: "ブラウザに拒否されました。このサイトの通知を許可してください",
+  },
+  "notify.job-failed": { en: "Job failed: {workflow}", ja: "ジョブ失敗: {workflow}" },
+  "notify.upstream-down": {
+    en: "Job server not answering: {server}",
+    ja: "ジョブサーバー応答なし: {server}",
+  },
+  "notify.upstream-up": {
+    en: "Job server back: {server}",
+    ja: "ジョブサーバー復帰: {server}",
+  },
+  "notify.comfy-crashed": {
+    en: "ComfyUI crashed — restarting it",
+    ja: "ComfyUI がクラッシュしました。再起動します",
+  },
+  "notify.comfy-gave-up": {
+    en: "ComfyUI keeps crashing — gave up restarting",
+    ja: "ComfyUI がクラッシュを繰り返すため、再起動を諦めました",
+  },
+
   "nav.label": { en: "Sections", ja: "セクション" },
   "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
   "nav.comfyui": { en: "ComfyUI", ja: "ComfyUI" },
@@ -332,6 +361,11 @@ const STRINGS = {
 } satisfies Record<string, Entry>;
 
 export type Key = keyof typeof STRINGS;
+
+/** Whether the table has words for `value` — for keys built at runtime. */
+export function isKey(value: string): value is Key {
+  return value in STRINGS;
+}
 
 const DEFAULT_LANG: Lang = LANGS[0].code;
 const STORAGE_KEY = "lang";

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -152,6 +152,13 @@
               <button type="button" data-close-action="quit" data-i18n="desktop.quit">Quits</button>
             </div>
 
+            <p class="popover-label" data-i18n="notify.label">Notifications</p>
+            <label class="switch">
+              <input type="checkbox" id="notify-enabled" />
+              <span data-i18n="notify.enable">Notify about failures</span>
+            </label>
+            <p class="muted" id="notify-note"></p>
+
             <p class="muted" data-i18n="desktop.note"></p>
             <p class="muted" id="desktop-note"></p>
           </div>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -3,6 +3,7 @@ import { agentSnapshot, applyUpstreamChange } from "../agent";
 import { interrupt, uploadImage, viewUrl } from "../comfy";
 import { comfyProcessState, startComfy, stopComfy } from "../comfy-process";
 import { COMFY_URL, UI_HOSTNAME, UI_PORT, UI_TOKEN, WORKFLOW_DIR } from "../config";
+import { listEvents } from "../events";
 import {
   clearFinishedJobs,
   completeJob,
@@ -63,6 +64,7 @@ async function handleState(): Promise<Response> {
     progress: latestProgress(),
     desktop: settings.desktop,
     jobs: listJobs(),
+    events: listEvents(),
   });
 }
 


### PR DESCRIPTION
Closes #22. #28(VRAM チップ)の上に積んだスタック PR です(3/7)。

ジョブの失敗・上流サーバーの断絶・ComfyUI のクラッシュに、画面を見ていなくても気づけるようにしました。

**作り**

- サーバー側に `src/events.ts`(直近 20 件のリングバッファ)を追加し、`/api/state` に `events` として載せます。サーバーは事実(kind + params)だけを記録し、文章は表示側が読者の言語で組み立てます。
- 発火点: `failJob`(ジョブ失敗、エラーは通知用に 200 字で切る。記録側は全文)/ ハートビートの ok↔ng 遷移(down・復帰。遷移のときだけで、落ち続けても連打しない)/ watchdog(クラッシュ→再起動、諦め)。
- UI はヘッダーのデスクトップメニューに通知スイッチを追加。オンにした瞬間に Web Notifications の許可を取り、拒否・非対応はスイッチを戻して理由を出します。
- 既読 id は localStorage に保存。イベント id は時刻ベースの単調増加なので、サーバーの再起動をまたいでも既読が壊れません。初回ポーリングのバックログは黙って既読化します(開いた瞬間に過去の失敗を連打しない)。通知オフの間も既読は進めるので、後からオンにしても履歴は再生されません。
- ページ側が知らない kind は落とさずスキップします(キャッシュされた古いページ対策)。

**割り切り(v1)**

ウィンドウを閉じてトレイ常駐中は、ブラウザのバックグラウンド タイマー抑制でポーリングが間引かれ、通知が遅れることがあります。Rust シェル側からの通知(tauri-plugin-notification)は別途やるのが良さそうですが、この PR ではスコープ外にしました。

**確認したこと**

- 死んだ上流サーバーを設定した統合テストで、`upstream-down` イベント(server 名入り)が `/api/state` に 1 件だけ載ること。
- 配信ページに通知スイッチが含まれること。
- `bun run check:ci` と `tsc --noEmit`。