### PR TITLE
feat(agent): retry a failed upstream job

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,11 +5,13 @@ import {
   AUTO_UPDATE,
   COMFY_URL,
   HEARTBEAT_INTERVAL_MS,
+  JOB_RETRIES,
   POLL_INTERVAL_MS,
+  RETRY_DELAY_MS,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./config";
 import { pushEvent } from "./events";
-import { completeJob, failJob, markQueued, startJob } from "./jobs";
+import { completeJob, failJob, markQueued, noteAttempt, startJob } from "./jobs";
 import { latestStatus, refreshStatus } from "./status";
 import { RESTART_EXIT_CODE, remoteHasUpdate } from "./updater";
 import { loadSettings } from "./settings";
@@ -113,39 +115,64 @@ async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
     workflow: workflowName,
   });
 
-  try {
-    let imageFilename: string | undefined;
-    if (claimed.sourceImageBase64) {
-      const contentType = claimed.sourceImageContentType || "image/png";
-      const ext = contentType.split("/")[1] ?? "png";
-      imageFilename = await uploadImage(
-        COMFY_URL,
-        `input_${claimed.jobId}.${ext}`,
-        contentType,
-        Buffer.from(claimed.sourceImageBase64, "base64"),
+  // A transient failure — a network blip, ComfyUI mid-restart — gets retried
+  // on this machine before the job server hears anything: the job is claimed
+  // and would not be handed out again anyway. Only claimed jobs retry; a run
+  // from the UI has someone watching it, who would not expect a quiet rerun.
+  const tries = 1 + JOB_RETRIES;
+
+  for (let attempt = 1; ; attempt++) {
+    if (attempt > 1) noteAttempt(job, attempt);
+
+    try {
+      let imageFilename: string | undefined;
+      if (claimed.sourceImageBase64) {
+        const contentType = claimed.sourceImageContentType || "image/png";
+        const ext = contentType.split("/")[1] ?? "png";
+        // The name repeats across attempts and the upload overwrites, so a
+        // retry cannot litter ComfyUI's input folder.
+        imageFilename = await uploadImage(
+          COMFY_URL,
+          `input_${claimed.jobId}.${ext}`,
+          contentType,
+          Buffer.from(claimed.sourceImageBase64, "base64"),
+        );
+        console.log(`[worker] uploaded input image → ${imageFilename}`);
+      }
+
+      const outputs = await runWorkflow(
+        workflowName,
+        { ...claimed.params, imageFilename },
+        (promptId) => markQueued(job, promptId),
       );
-      console.log(`[worker] uploaded input image → ${imageFilename}`);
+
+      // Upstreams expect a single artefact. Video workflows also emit preview
+      // images, so prefer a playable file over whatever happens to come first.
+      const primary = outputs.find((output) => output.kind === "video") ?? outputs[0]!;
+      await uploadResult(server, claimed.jobId, primary.url);
+      await reportComplete(server, claimed.jobId);
+
+      completeJob(job, outputs);
+      console.log(`[worker] job ${claimed.jobId} completed`);
+      return;
+    } catch (err) {
+      const reason = message(err);
+
+      if (attempt < tries && running) {
+        console.error(
+          `[worker] job ${claimed.jobId} attempt ${attempt}/${tries} failed: ${reason}` +
+            ` — retrying in ${Math.round(RETRY_DELAY_MS / 1000)} s`,
+        );
+        await idle(RETRY_DELAY_MS);
+        // The agent was stopped mid-wait; report rather than run on regardless.
+        if (running) continue;
+      }
+
+      console.error(`[worker] job ${claimed.jobId} failed: ${reason}`);
+      failJob(job, reason);
+      await reportFailure(server, claimed.jobId, reason);
+      return;
     }
-
-    const outputs = await runWorkflow(
-      workflowName,
-      { ...claimed.params, imageFilename },
-      (promptId) => markQueued(job, promptId),
-    );
-
-    // Upstreams expect a single artefact. Video workflows also emit preview
-    // images, so prefer a playable file over whatever happens to come first.
-    const primary = outputs.find((output) => output.kind === "video") ?? outputs[0]!;
-    await uploadResult(server, claimed.jobId, primary.url);
-    await reportComplete(server, claimed.jobId);
-
-    completeJob(job, outputs);
-    console.log(`[worker] job ${claimed.jobId} completed`);
-  } catch (err) {
-    const reason = message(err);
-    console.error(`[worker] job ${claimed.jobId} failed: ${reason}`);
-    failJob(job, reason);
-    await reportFailure(server, claimed.jobId, reason);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,14 @@ export const HEARTBEAT_INTERVAL_MS = Number(process.env.HEARTBEAT_INTERVAL_MS ??
 /** How long a single ComfyUI run may take before it is abandoned. */
 export const JOB_TIMEOUT_MS = Number(process.env.JOB_TIMEOUT_MS ?? "600000");
 
+/**
+ * Extra tries an upstream job gets on this machine before its failure is
+ * reported. A transient failure — a network blip, ComfyUI mid-restart — is
+ * cheaper to retry here than to bounce back through the job server.
+ */
+export const JOB_RETRIES = Number(process.env.JOB_RETRIES ?? "2");
+export const RETRY_DELAY_MS = Number(process.env.RETRY_DELAY_MS ?? "10000");
+
 export const AUTO_UPDATE = (process.env.AUTO_UPDATE ?? "false") !== "false";
 export const UPDATE_CHECK_INTERVAL_MS = Number(process.env.UPDATE_CHECK_INTERVAL_MS ?? "60000");
 

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -72,6 +72,12 @@ export function markQueued(job: JobRecord, promptId: string): void {
   persist();
 }
 
+/** Records that the job is on its `attempt`-th try, so the UI can say so. */
+export function noteAttempt(job: JobRecord, attempt: number): void {
+  job.attempts = attempt;
+  persist();
+}
+
 export function completeJob(job: JobRecord, outputs: RunOutput[]): void {
   job.state = "succeeded";
   job.outputs = outputs;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,8 @@ export type JobRecord = {
   promptId?: string;
   outputs?: RunOutput[];
   error?: string;
+  /** Tries this job has had on this machine; absent means the first. */
+  attempts?: number;
   /**
    * The process died while this job was running. Flagged rather than left to
    * `error` alone so the UI can say it in the reader's own language.

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -51,6 +51,8 @@ type JobRecord = {
   promptId?: string;
   outputs?: RunOutput[];
   error?: string;
+  /** Tries this job has had on this machine; absent means the first. */
+  attempts?: number;
   interrupted?: boolean;
 };
 
@@ -735,6 +737,8 @@ function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress
     </div>
     <p class="meta">${formatTime(job.startedAt)} · ${timing}${origin}${
       job.promptId ? ` · ${t("jobs.prompt", { id: esc(job.promptId.slice(0, 8)) })}` : ""
+    }${
+      job.attempts && job.attempts > 1 ? ` · ${t("jobs.attempt", { count: job.attempts })}` : ""
     }</p>
     ${progressBar(job, progress)}
     ${jobError(job)}

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -218,6 +218,7 @@ const STRINGS = {
     ja: "{percent}% · {value}/{max} ステップ",
   },
   "jobs.node": { en: "node {node}", ja: "ノード {node}" },
+  "jobs.attempt": { en: "attempt {count}", ja: "試行 {count} 回目" },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 


### PR DESCRIPTION
Closes #23. #29(通知)の上に積んだスタック PR です(4/7)。

一時的なエラー(ネットワーク断、ComfyUI の再起動直後など)で即 fail を報告していたのを、同じマシンで 2 回まで再試行してから報告するようにしました(計 3 回、`JOB_RETRIES` / `RETRY_DELAY_MS` 環境変数で変更可、既定 10 秒間隔)。watchdog(#27)が ComfyUI を立て直す 5 秒より長いので、クラッシュ→再起動→リトライ成功の流れが噛み合います。

**作り**

- 対象は上流から claim したジョブだけです。claim 済みジョブはサーバーから再配布されないので、このマシンで粘るのが唯一のリカバリ経路です。UI からの手動実行は見ている人がいるので黙って再実行しません。
- 入力画像のアップロードもループ内なので、ComfyUI が落ちていた場合も再試行で再アップロードされます。ファイル名がジョブ ID 固定 + overwrite なので再試行がゴミを増やしません。
- 履歴レコードに `attempts` を追加し、2 回目以降は Runs の行に「attempt N / 試行 N 回目」が出ます。成功してもかかった試行数は残ります。
- エージェント停止(設定変更・シャットダウン)が再試行待ちに入ったら、粘らずにその時点の理由で fail を報告します。
- fail 報告は最終失敗の 1 回だけ。通知イベント(#29 の `job-failed`)も `failJob` 経由なので 1 回だけ発火します。

**確認したこと**

モック(claim を 1 件だけ返すジョブサーバー + `/prompt` が常に 500 の ComfyUI)での E2E:

- `/prompt` がちょうど 3 回叩かれ、`/fail` の報告は 1 回、理由はサーバーの文言のまま。
- 履歴が `state: failed, attempts: 3`、イベントは `job-failed` が 1 件。
- `bun run check:ci` と `tsc --noEmit`。