### PR TITLE
feat(outputs): show and trim the ComfyUI output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ done with.
 command to run there — and starts and stops it, with the tail of its output so
 a wrong command explains itself. A ComfyUI started here that crashes is started
 again on its own; three crashes in a row right after starting read as a broken
-command, so it stops trying and says why in the log.
+command, so it stops trying and says why in the log. An *Outputs* panel shows
+how much disk ComfyUI's output folder holds, with a button — and an optional
+standing rule — that deletes files older than a chosen number of days.
 
 **Servers** attaches job servers: link one with a code from its own UI, or fill
 a row in by hand; reorder and disable them here too. The order is the priority.

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,7 +14,8 @@ export type UiEventKind =
   | "upstream-down"
   | "upstream-up"
   | "comfy-crashed"
-  | "comfy-gave-up";
+  | "comfy-gave-up"
+  | "outputs-trimmed";
 
 export type UiEvent = {
   id: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { startAgent, stopAgent } from "./agent";
 import { startComfyWatch, stopComfy } from "./comfy-process";
 import { COMFY_URL, DATA_DIR, UI_ENABLED, WORKFLOW_DIR } from "./config";
 import { loadJobs } from "./jobs";
+import { startOutputWatch } from "./outputs";
 import { startProgressWatch, stopProgressWatch } from "./progress";
 import { loadSettings } from "./settings";
 import { startStatusPolling } from "./status";
@@ -37,6 +38,7 @@ if (names.length === 0) {
 
 const statusTimer = startStatusPolling(STATUS_POLL_MS);
 const comfyWatch = startComfyWatch();
+const outputWatch = startOutputWatch();
 startProgressWatch();
 
 if (UI_ENABLED) {
@@ -56,6 +58,7 @@ function shutdown() {
   stopAgent();
   clearInterval(statusTimer);
   clearInterval(comfyWatch);
+  clearInterval(outputWatch);
   stopProgressWatch();
   void stopComfy();
   process.exit(0);

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -1,0 +1,144 @@
+/**
+ * ComfyUI's output folder, watched and trimmed.
+ *
+ * Video workflows fill the disk quietly — nothing in ComfyUI ever deletes an
+ * output. This keeps a cheap running total (files and bytes) for the UI, and
+ * deletes files older than a chosen age: on demand from a button, and on a
+ * timer when `outputCleanupDays` is set.
+ *
+ * Only files under the output directory are ever touched, and directories are
+ * left in place. The scan is cached and redone on a slow timer rather than per
+ * request — the UI polls every two seconds, and a large folder should not be
+ * walked at that pace.
+ */
+
+import { existsSync } from "node:fs";
+import { readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { pushEvent } from "./events";
+import { loadSettings } from "./settings";
+
+const SCAN_INTERVAL_MS = 10 * 60_000;
+const DAY_MS = 86_400_000;
+
+export type OutputsSnapshot = {
+  dir: string;
+  files: number;
+  bytes: number;
+  scannedAt: number;
+};
+
+let snapshot: OutputsSnapshot | null = null;
+
+/**
+ * Where ComfyUI writes its outputs, mirroring how `resolveCommand` reads the
+ * directory: the portable bundle keeps ComfyUI one level down.
+ */
+export function outputDirFor(comfyDir: string): string | null {
+  if (!comfyDir) return null;
+  const portable = join(comfyDir, "ComfyUI", "output");
+  if (existsSync(portable)) return portable;
+  const plain = join(comfyDir, "output");
+  return existsSync(plain) ? plain : null;
+}
+
+async function walk(
+  dir: string,
+  visit: (path: string, size: number, mtimeMs: number) => void,
+): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(path, visit);
+    } else if (entry.isFile()) {
+      const stats = await stat(path).catch(() => null);
+      if (stats) visit(path, stats.size, stats.mtimeMs);
+    }
+  }
+}
+
+export function outputsSnapshot(): OutputsSnapshot | null {
+  return snapshot;
+}
+
+export async function rescanOutputs(): Promise<OutputsSnapshot | null> {
+  const dir = outputDirFor((await loadSettings()).comfyDir);
+  if (!dir) {
+    snapshot = null;
+    return null;
+  }
+
+  let files = 0;
+  let bytes = 0;
+  await walk(dir, (_path, size) => {
+    files += 1;
+    bytes += size;
+  });
+
+  snapshot = { dir, files, bytes, scannedAt: Date.now() };
+  return snapshot;
+}
+
+/** "3.2 GB" or "410 MB" — for logs and notifications, not for the record. */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+/**
+ * Delete every file older than `days` under the output folder. A file that
+ * refuses to go — held open by a player, say — is skipped, not fatal: the next
+ * sweep gets another chance at it.
+ */
+export async function trimOutputs(
+  days: number,
+): Promise<{ removedFiles: number; removedBytes: number }> {
+  const dir = outputDirFor((await loadSettings()).comfyDir);
+  if (!dir) throw new Error("no output folder found — set the ComfyUI directory first");
+
+  const cutoff = Date.now() - days * DAY_MS;
+  const doomed: { path: string; size: number }[] = [];
+  await walk(dir, (path, size, mtimeMs) => {
+    if (mtimeMs < cutoff) doomed.push({ path, size });
+  });
+
+  let removedFiles = 0;
+  let removedBytes = 0;
+  for (const file of doomed) {
+    try {
+      await rm(file.path);
+      removedFiles += 1;
+      removedBytes += file.size;
+    } catch {
+      // Skipped this sweep; it stays in the count the rescan reports.
+    }
+  }
+
+  await rescanOutputs();
+  return { removedFiles, removedBytes };
+}
+
+/** One pass of the timer: apply the stored rule, or just refresh the count. */
+async function sweep(): Promise<void> {
+  const settings = await loadSettings();
+
+  if (settings.outputCleanupDays > 0 && outputDirFor(settings.comfyDir)) {
+    const { removedFiles, removedBytes } = await trimOutputs(settings.outputCleanupDays);
+    if (removedFiles > 0) {
+      console.log(`[outputs] removed ${removedFiles} file(s), ${formatBytes(removedBytes)}`);
+      pushEvent("outputs-trimmed", {
+        files: String(removedFiles),
+        size: formatBytes(removedBytes),
+      });
+    }
+    return; // trimOutputs rescanned already
+  }
+
+  await rescanOutputs();
+}
+
+export function startOutputWatch(): ReturnType<typeof setInterval> {
+  void sweep();
+  return setInterval(() => void sweep(), SCAN_INTERVAL_MS);
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -88,6 +88,11 @@ export type Settings = {
    * quietly start claiming again.
    */
   pauseUntil: number | null;
+  /**
+   * Outputs older than this many days are deleted by the sweep in
+   * `outputs.ts`. `0` — the default — means never delete anything.
+   */
+  outputCleanupDays: number;
   desktop: DesktopSettings;
 };
 
@@ -99,6 +104,7 @@ const EMPTY: Settings = {
   mode: "accepting",
   schedule: EMPTY_SCHEDULE,
   pauseUntil: null,
+  outputCleanupDays: 0,
   desktop: { autostart: false, closeAction: "tray" },
 };
 
@@ -170,6 +176,13 @@ function normaliseSchedule(raw: unknown): AcceptSchedule {
   };
 }
 
+/** Anything a day count cannot be — negative, NaN, absent — means "off". */
+export function normaliseCleanupDays(raw: unknown): number {
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 1
+    ? Math.min(3650, Math.floor(raw))
+    : 0;
+}
+
 function normaliseDesktop(raw: unknown): DesktopSettings {
   const value = (raw ?? {}) as Partial<DesktopSettings>;
   return {
@@ -192,6 +205,7 @@ function normalise(raw: unknown): Settings {
     mode: normaliseMode(value),
     schedule: normaliseSchedule(value.schedule),
     pauseUntil: typeof value.pauseUntil === "number" ? value.pauseUntil : null,
+    outputCleanupDays: normaliseCleanupDays(value.outputCleanupDays),
     desktop: normaliseDesktop(value.desktop),
   };
 }

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -98,7 +98,9 @@ type State = {
     }[];
   };
   upstreams: UpstreamView[];
-  settings: { comfyDir: string; comfyCommand: string };
+  settings: { comfyDir: string; comfyCommand: string; outputCleanupDays: number };
+  /** ComfyUI's output folder as last scanned; null when there is none. */
+  outputs: { dir: string; files: number; bytes: number; scannedAt: number } | null;
   mode: RunMode;
   accepting: {
     accepting: boolean;
@@ -176,6 +178,12 @@ const nodes = {
   desktopNote: el("desktop-note"),
   notifyEnabled: el<HTMLInputElement>("notify-enabled"),
   notifyNote: el("notify-note"),
+  outputsDir: el("outputs-dir"),
+  outputsInfo: el("outputs-info"),
+  outputsDays: el<HTMLInputElement>("outputs-days"),
+  outputsAuto: el<HTMLInputElement>("outputs-auto"),
+  outputsTrim: el<HTMLButtonElement>("outputs-trim"),
+  outputsNote: el("outputs-note"),
 };
 
 function esc(value: unknown): string {
@@ -209,6 +217,12 @@ function progressPercent(progress: { value: number; max: number }): number {
 /** Bytes as gigabytes with one decimal, the unit VRAM is talked about in. */
 function gb(bytes: number): string {
   return (bytes / 1024 ** 3).toFixed(1);
+}
+
+/** "3.2 GB" or "410 MB", for sizes whose scale is not known in advance. */
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${gb(bytes)} GB`;
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -768,6 +782,59 @@ function syncSettings(state: State): void {
 }
 
 // ---------------------------------------------------------------------------
+// Outputs — ComfyUI's output folder
+// ---------------------------------------------------------------------------
+
+function syncOutputs(state: State): void {
+  if (!state.outputs) {
+    nodes.outputsDir.textContent = "";
+    nodes.outputsInfo.textContent = t("outputs.none");
+    nodes.outputsTrim.disabled = true;
+  } else {
+    nodes.outputsDir.textContent = state.outputs.dir;
+    nodes.outputsInfo.textContent = t("outputs.count", {
+      files: state.outputs.files,
+      size: formatBytes(state.outputs.bytes),
+    });
+    nodes.outputsTrim.disabled = false;
+  }
+
+  // Like the schedule times: only the field being typed into is left alone.
+  if (document.activeElement !== nodes.outputsAuto) {
+    nodes.outputsAuto.value = String(state.settings.outputCleanupDays);
+  }
+}
+
+async function trimOutputsNow(): Promise<void> {
+  const days = Number(nodes.outputsDays.value);
+  if (!Number.isFinite(days) || days < 1) {
+    setNote(nodes.outputsNote, t("outputs.needDays"), true);
+    return;
+  }
+  if (!confirm(t("outputs.confirm", { days }))) return;
+
+  nodes.outputsTrim.disabled = true;
+  setNote(nodes.outputsNote, t("outputs.trimming"));
+  const result = await post<{ removedFiles: number; removedBytes: number }>("/api/outputs/trim", {
+    days,
+  });
+  nodes.outputsTrim.disabled = false;
+
+  if (!result.ok) {
+    setNote(nodes.outputsNote, result.error ?? t("outputs.trimFailed"), true);
+    return;
+  }
+  setNote(
+    nodes.outputsNote,
+    t("outputs.trimmed", {
+      files: result.data?.removedFiles ?? 0,
+      size: formatBytes(result.data?.removedBytes ?? 0),
+    }),
+  );
+  void poll();
+}
+
+// ---------------------------------------------------------------------------
 // Header menus
 // ---------------------------------------------------------------------------
 
@@ -1083,6 +1150,7 @@ function render(state: State): void {
   syncServers(state);
   renderJobs(state);
   syncSettings(state);
+  syncOutputs(state);
   syncMode(state);
   syncAccepting(state);
   syncDesktop(state);
@@ -1459,6 +1527,22 @@ async function toggleComfy(): Promise<void> {
 
 nodes.comfyPower.addEventListener("click", () => void toggleComfy());
 nodes.comfyPower2.addEventListener("click", () => void toggleComfy());
+
+nodes.outputsTrim.addEventListener("click", () => void trimOutputsNow());
+
+// Saved on change like the schedule: one number is not worth a Save button.
+nodes.outputsAuto.addEventListener("change", async () => {
+  const days = Number(nodes.outputsAuto.value);
+  const result = await post("/api/settings", {
+    outputCleanupDays: Number.isFinite(days) ? days : 0,
+  });
+  setNote(
+    nodes.outputsNote,
+    result.ok ? t("outputs.saved") : (result.error ?? t("comfy.saveFailed")),
+    !result.ok,
+  );
+  void poll();
+});
 
 nodes.desktopOpen.addEventListener("click", () => toggle(DESKTOP_POPOVER));
 nodes.modeOpen.addEventListener("click", () => toggle(MODE_POPOVER));

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -144,6 +144,10 @@ const STRINGS = {
     en: "ComfyUI keeps crashing — gave up restarting",
     ja: "ComfyUI がクラッシュを繰り返すため、再起動を諦めました",
   },
+  "notify.outputs-trimmed": {
+    en: "Old outputs deleted: {files} files ({size})",
+    ja: "古い出力を削除しました: {files} ファイル（{size}）",
+  },
 
   "nav.label": { en: "Sections", ja: "セクション" },
   "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
@@ -289,6 +293,32 @@ const STRINGS = {
   },
   "process.startedAt": { en: "started {time} · pid {pid}", ja: "{time} に起動 · pid {pid}" },
   "process.foreign": { en: "not started from here", ja: "ここからは起動していません" },
+
+  // ComfyUI's output folder --------------------------------------------------
+  "outputs.title": { en: "Outputs", ja: "出力ファイル" },
+  "outputs.none": {
+    en: "No output folder under the ComfyUI directory yet.",
+    ja: "ComfyUI ディレクトリの下に output フォルダがまだありません。",
+  },
+  "outputs.count": { en: "{files} files · {size}", ja: "{files} ファイル · {size}" },
+  "outputs.olderThan": { en: "Older than (days)", ja: "何日より古いか" },
+  "outputs.auto": {
+    en: "Auto-delete after (days, 0 = off)",
+    ja: "自動削除する日数（0 = オフ）",
+  },
+  "outputs.trim": { en: "Delete old outputs", ja: "古い出力を削除" },
+  "outputs.confirm": {
+    en: "Delete outputs older than {days} days? The files are removed from disk.",
+    ja: "{days} 日より古い出力を削除しますか？ディスクからファイルが消えます。",
+  },
+  "outputs.needDays": { en: "enter how many days", ja: "日数を入力してください" },
+  "outputs.trimming": { en: "deleting…", ja: "削除中…" },
+  "outputs.trimFailed": { en: "delete failed", ja: "削除できませんでした" },
+  "outputs.trimmed": {
+    en: "removed {files} files ({size})",
+    ja: "{files} ファイル（{size}）を削除しました",
+  },
+  "outputs.saved": { en: "saved", ja: "保存しました" },
 
   // Upstream servers --------------------------------------------------------
   "servers.title": { en: "Upstream servers", ja: "上流サーバー" },

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -415,6 +415,30 @@
             </div>
             <div id="comfy-process"></div>
           </section>
+
+          <!-- What ComfyUI's output folder holds. Nothing in ComfyUI ever
+               deletes an output, so the disk fills quietly without this. -->
+          <section class="panel">
+            <div class="panel-head"><h2 data-i18n="outputs.title">Outputs</h2></div>
+            <p class="mono muted" id="outputs-dir"></p>
+            <p class="muted" id="outputs-info"></p>
+            <div class="row">
+              <label class="field">
+                <span data-i18n="outputs.olderThan">Older than (days)</span>
+                <input type="number" id="outputs-days" min="1" value="30" />
+              </label>
+              <label class="field">
+                <span data-i18n="outputs.auto">Auto-delete after (days, 0 = off)</span>
+                <input type="number" id="outputs-auto" min="0" />
+              </label>
+            </div>
+            <div class="actions">
+              <button type="button" class="ghost danger" id="outputs-trim" data-i18n="outputs.trim">
+                Delete old outputs
+              </button>
+              <p class="muted" id="outputs-note"></p>
+            </div>
+          </section>
         </section>
 
         <section class="page" data-page="servers" hidden>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -13,12 +13,14 @@ import {
   removeJob,
   startJob,
 } from "../jobs";
+import { outputsSnapshot, rescanOutputs, trimOutputs } from "../outputs";
 import { latestProgress } from "../progress";
 import {
   RUN_MODES,
   hostFromUrl,
   loadSettings,
   newUpstreamId,
+  normaliseCleanupDays,
   publicUpstreams,
   saveSettings,
 } from "../settings";
@@ -58,7 +60,12 @@ async function handleState(): Promise<Response> {
     activeWorkflow: await activeWorkflowName(),
     agent: agentSnapshot(),
     upstreams: publicUpstreams(settings),
-    settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
+    settings: {
+      comfyDir: settings.comfyDir,
+      comfyCommand: settings.comfyCommand,
+      outputCleanupDays: settings.outputCleanupDays,
+    },
+    outputs: outputsSnapshot(),
     mode: settings.mode,
     accepting: acceptState(settings),
     progress: latestProgress(),
@@ -265,14 +272,43 @@ async function handleLink(req: Request): Promise<Response> {
 
 async function handleSettingsSave(req: Request): Promise<Response> {
   try {
-    const body = (await req.json()) as { comfyDir?: string; comfyCommand?: string };
+    const body = (await req.json()) as {
+      comfyDir?: string;
+      comfyCommand?: string;
+      outputCleanupDays?: unknown;
+    };
     const saved = await saveSettings({
       ...(body.comfyDir === undefined ? {} : { comfyDir: body.comfyDir.trim() }),
       ...(body.comfyCommand === undefined ? {} : { comfyCommand: body.comfyCommand.trim() }),
+      ...(body.outputCleanupDays === undefined
+        ? {}
+        : { outputCleanupDays: normaliseCleanupDays(body.outputCleanupDays) }),
     });
+    // A different directory means a different output folder to count.
+    if (body.comfyDir !== undefined) void rescanOutputs();
     return Response.json({
-      settings: { comfyDir: saved.comfyDir, comfyCommand: saved.comfyCommand },
+      settings: {
+        comfyDir: saved.comfyDir,
+        comfyCommand: saved.comfyCommand,
+        outputCleanupDays: saved.outputCleanupDays,
+      },
     });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * Delete outputs older than the given days, right now. The stored rule is the
+ * quiet version of this; the button wants its result in the response.
+ */
+async function handleOutputsTrim(req: Request): Promise<Response> {
+  try {
+    const { days } = (await req.json()) as { days?: unknown };
+    if (typeof days !== "number" || !Number.isFinite(days) || days < 1 || days > 3650) {
+      return fail("days must be a number between 1 and 3650");
+    }
+    return Response.json(await trimOutputs(Math.floor(days)));
   } catch (err) {
     return fail(err);
   }
@@ -571,6 +607,7 @@ export function startUi() {
       "/api/link": { POST: guarded(handleLink) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
+      "/api/outputs/trim": { POST: guarded(handleOutputsTrim) },
       "/api/mode": { POST: guarded(handleMode) },
       "/api/accept/pause": { POST: guarded(handlePause) },
       "/api/accept/schedule": { POST: guarded(handleScheduleSave) },


### PR DESCRIPTION
Closes #24. #30(リトライ)の上に積んだスタック PR です(5/7)。

ComfyUI の output フォルダは何も消さないので黙って膨らみ続けます。ComfyUI ページに *Outputs* パネルを追加し、使用量の表示と、古いファイルの削除(手動ボタン + 自動ルール)を付けました。

**作り**

- `src/outputs.ts` を新設。出力フォルダは `resolveCommand` と同じ読み方で解決します(ポータブル版は `<dir>/ComfyUI/output`、それ以外は `<dir>/output`)。
- スキャン(ファイル数 + 合計バイト)は 10 分ごとのタイマーでキャッシュし、`/api/state` はキャッシュを返すだけです。2 秒ポーリングで大きなフォルダを歩かないためです。ディレクトリ設定の変更時は再スキャンします。
- 手動削除: `POST /api/outputs/trim { days }`(1〜3650 でバリデーション)。UI は confirm を挟み、結果(N ファイル / サイズ)を行に出します。
- 自動削除: 設定 `outputCleanupDays`(0 = オフ、既定 0)。タイマーの sweep が適用し、消した分は `outputs-trimmed` イベント → #29 の通知に載ります。日数の保存はスケジュール欄と同じ「変更即保存」です。
- 消すのは output ディレクトリ配下の**ファイルだけ**。ディレクトリは残します。開かれたままで消せないファイルはスキップして次回に回します。
- 削除された出力を参照する履歴のサムネイルは 404 になります(ComfyUI 側で手で消しても同じことが起きるので、許容としました)。

**確認したこと(実ファイルでの E2E)**

- 古いファイル 2 件(サブディレクトリ含む)+ 新しい 2 件を置き、スナップショットが 4 件 → 手動 trim(30 日)で古い 2 件だけ消え、レスポンスの件数・バイト数も一致。
- `days: 0` は 400 で拒否。
- `outputCleanupDays: 30` を設定して起動 → 起動時 sweep が古い 1 件を削除し、`outputs-trimmed` イベント(1 ファイル / 1 MB)が発火。
- `bun run check:ci` と `tsc --noEmit`。