### PR TITLE
feat(runs): filter the history and a gallery view

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ details.
 
 **Generate** runs a workflow by hand: a form on one side, the run history on the
 other. Handy for checking a workflow does what you think before a job server
-starts sending work.
+starts sending work. The history narrows by state and by where the job came
+from, and flips into a gallery of everything the filtered runs produced.
 
 A run in flight carries a bar — the steps ComfyUI has done out of the steps it
 expects, and the node it is on — so a slow workflow can be told from a stuck one.

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -760,12 +760,62 @@ function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress
   </div>`;
 }
 
+// Page-local: the history itself is what it is, only its reading is chosen.
+type JobStateFilter = "all" | JobRecord["state"];
+type JobSourceFilter = "all" | JobRecord["source"];
+type JobsView = "list" | "gallery";
+
+let jobStateFilter: JobStateFilter = "all";
+let jobSourceFilter: JobSourceFilter = "all";
+let jobsView: JobsView = "list";
+
+/**
+ * Every image and video the filtered runs produced, newest first, each cell
+ * opening (or playing) the file itself. Failures and files that are neither
+ * are the list view's business.
+ */
+function galleryHtml(jobs: JobRecord[]): string {
+  const cells: string[] = [];
+  for (const job of jobs) {
+    for (const output of job.outputs ?? []) {
+      const url = outputUrl(output);
+      const name = esc(output.filename);
+      const caption = `${esc(job.workflow)} · ${formatTime(job.startedAt)}`;
+      if (output.kind === "image") {
+        cells.push(
+          `<a class="cell" href="${url}" target="_blank" rel="noreferrer" title="${caption}">` +
+            `<img src="${url}" alt="${name}" loading="lazy" /></a>`,
+        );
+      } else if (output.kind === "video") {
+        cells.push(
+          `<div class="cell" title="${caption}">` +
+            `<video src="${url}" controls preload="metadata" title="${name}"></video></div>`,
+        );
+      }
+    }
+  }
+  if (cells.length === 0) return `<p class="empty">${t("jobs.noMedia")}</p>`;
+  return `<div class="gallery">${cells.join("")}</div>`;
+}
+
 function renderJobs(state: State): void {
-  if (state.jobs.length === 0) {
-    renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${t("jobs.empty")}</p>`);
+  const jobs = state.jobs.filter(
+    (job) =>
+      (jobStateFilter === "all" || job.state === jobStateFilter) &&
+      (jobSourceFilter === "all" || job.source === jobSourceFilter),
+  );
+
+  if (jobsView === "gallery") {
+    renderIfChanged(nodes.jobs, "jobs", galleryHtml(jobs));
     return;
   }
-  const html = state.jobs.map((job) => jobEntry(job, true, state.progress)).join("");
+  if (jobs.length === 0) {
+    // An empty history and a filter that matched nothing read differently.
+    const text = state.jobs.length === 0 ? t("jobs.empty") : t("jobs.noMatch");
+    renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${text}</p>`);
+    return;
+  }
+  const html = jobs.map((job) => jobEntry(job, true, state.progress)).join("");
   renderIfChanged(nodes.jobs, "jobs", `<div class="ledger">${html}</div>`);
 }
 
@@ -1492,6 +1542,44 @@ nodes.jobs.addEventListener("click", async (event) => {
   lastHtml.delete("jobs");
   void poll();
 });
+
+function syncJobFilterButtons(): void {
+  const groups: [attribute: string, current: string][] = [
+    ["data-job-state", jobStateFilter],
+    ["data-job-source", jobSourceFilter],
+    ["data-job-view", jobsView],
+  ];
+  for (const [attribute, current] of groups) {
+    for (const button of document.querySelectorAll<HTMLElement>(`[${attribute}]`)) {
+      button.setAttribute("aria-pressed", String(button.getAttribute(attribute) === current));
+    }
+  }
+}
+
+/** The three groups differ only in which variable a click sets. */
+function wireJobFilter(id: string, attribute: string, apply: (value: string) => void): void {
+  el(id).addEventListener("click", (event) => {
+    const value = (event.target as HTMLElement)
+      .closest<HTMLElement>(`[${attribute}]`)
+      ?.getAttribute(attribute);
+    if (!value) return;
+    apply(value);
+    syncJobFilterButtons();
+    if (latestState) renderJobs(latestState);
+  });
+}
+
+wireJobFilter("jobs-state", "data-job-state", (value) => {
+  jobStateFilter = value as JobStateFilter;
+});
+wireJobFilter("jobs-source", "data-job-source", (value) => {
+  jobSourceFilter = value as JobSourceFilter;
+});
+wireJobFilter("jobs-view", "data-job-view", (value) => {
+  jobsView = value as JobsView;
+});
+
+syncJobFilterButtons();
 
 nodes.settingsForm.addEventListener("input", () => {
   settingsDirty = true;

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -223,6 +223,20 @@ const STRINGS = {
   },
   "jobs.node": { en: "node {node}", ja: "ノード {node}" },
   "jobs.attempt": { en: "attempt {count}", ja: "試行 {count} 回目" },
+  "jobs.all": { en: "All", ja: "すべて" },
+  "jobs.filterState": { en: "State", ja: "状態" },
+  "jobs.filterSource": { en: "Source", ja: "発生元" },
+  "jobs.filterView": { en: "View", ja: "表示" },
+  "jobs.listView": { en: "List", ja: "リスト" },
+  "jobs.galleryView": { en: "Gallery", ja: "ギャラリー" },
+  "jobs.noMatch": {
+    en: "Nothing in the history matches the filter.",
+    ja: "条件に合う履歴はありません。",
+  },
+  "jobs.noMedia": {
+    en: "No images or videos in the filtered runs yet.",
+    ja: "条件に合う画像・動画はまだありません。",
+  },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -339,6 +339,87 @@
                   Clear finished
                 </button>
               </div>
+
+              <!-- Narrowing and reshaping only — the history itself is what it
+                   is. The choices live in the page, not on the server. -->
+              <div class="filters">
+                <div
+                  class="segmented text"
+                  id="jobs-state"
+                  role="group"
+                  data-i18n-label="jobs.filterState"
+                >
+                  <button type="button" data-job-state="all" data-i18n="jobs.all">All</button>
+                  <button type="button" data-job-state="running" data-i18n="jobs.running">
+                    running
+                  </button>
+                  <button type="button" data-job-state="succeeded" data-i18n="jobs.succeeded">
+                    succeeded
+                  </button>
+                  <button type="button" data-job-state="failed" data-i18n="jobs.failed">
+                    failed
+                  </button>
+                </div>
+                <div
+                  class="segmented text"
+                  id="jobs-source"
+                  role="group"
+                  data-i18n-label="jobs.filterSource"
+                >
+                  <button type="button" data-job-source="all" data-i18n="jobs.all">All</button>
+                  <button type="button" data-job-source="ui" data-i18n="jobs.ui">UI</button>
+                  <button type="button" data-job-source="upstream" data-i18n="jobs.upstream">
+                    upstream
+                  </button>
+                </div>
+                <div
+                  class="segmented"
+                  id="jobs-view"
+                  role="group"
+                  data-i18n-label="jobs.filterView"
+                >
+                  <button
+                    type="button"
+                    data-job-view="list"
+                    data-i18n-title="jobs.listView"
+                    aria-pressed="true"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <span class="sr-only" data-i18n="jobs.listView">List</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-job-view="gallery"
+                    data-i18n-title="jobs.galleryView"
+                    aria-pressed="false"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      aria-hidden="true"
+                    >
+                      <rect x="4" y="4" width="7" height="7" rx="1" />
+                      <rect x="13" y="4" width="7" height="7" rx="1" />
+                      <rect x="4" y="13" width="7" height="7" rx="1" />
+                      <rect x="13" y="13" width="7" height="7" rx="1" />
+                    </svg>
+                    <span class="sr-only" data-i18n="jobs.galleryView">Gallery</span>
+                  </button>
+                </div>
+              </div>
+
               <div id="jobs"></div>
             </section>
           </div>

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -972,6 +972,36 @@ button.ghost.danger:hover:not(:disabled) {
   background: var(--canvas);
 }
 
+/* Narrowing the run history, and switching how it is drawn. */
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  margin-bottom: var(--space-2xs);
+}
+
+/* Every picture the filtered runs produced, packed edge to edge. */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: var(--space-2xs);
+}
+
+.gallery .cell {
+  display: block;
+}
+
+.gallery img,
+.gallery video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--canvas);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
Closes #25. #31(出力管理)の上に積んだスタック PR です(6/7)。

Runs パネルにフィルタと表示切り替えを付けました。サーバー側の変更はありません。

**作り**

- 状態(all / running / succeeded / failed)と発生元(all / UI / upstream)のセグメントコントロール、リスト / ギャラリーの表示切り替え。選択はページ内の変数だけで、既存の `renderIfChanged` が HTML の差分で再描画するので、キー管理の追加はありません。
- ギャラリーは絞り込んだ実行の出力(画像・動画)をグリッドで並べます。画像はクリックで原寸を開き、動画はその場で再生できます。セルの title にワークフロー名と時刻が入ります。`loading="lazy"` 付きなので 200 件の履歴でも一度に読みません。
- 「履歴が空」と「フィルタに合うものがない」は文言を分けました。
- 3 つのグループの配線は同型なので `wireJobFilter()` に畳んであります。

**確認したこと**

- HTML パースでグループ 3 つとボタンの値がそろっていること、`data-i18n` キーが全て `i18n.ts` にあること(数字入りキーも拾う正規表現で再確認)。
- 実サーバーで配信されること。
- `bun run check:ci`(oxfmt が HTML を整形)と `tsc --noEmit`。