### PR TITLE
feat(workflows): check a workflow against ComfyUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ The Workflows page shows which of these were found, so a workflow that needs hel
 is obvious before you run it. Anything not found is simply not offered — a
 workflow with no `LoadImage` gets no image field.
 
+*Check* on a workflow's row goes further: it asks the running ComfyUI — via
+`/object_info` — whether every node type in the file exists there, and whether
+every file-choosing input (checkpoints, LoRAs, VAEs, …) names something
+actually installed, without running anything. Inputs the app replaces at run
+time, the input image above all, are left out of the check.
+
 Outputs are not detected in advance. Whatever ComfyUI records in its history for
 the run is collected, so images, videos and gifs all work with no configuration.
 

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -472,6 +472,36 @@ function slotTags(summary: WorkflowSummary): string {
   return `<div class="slots">${tags.join("")}</div>`;
 }
 
+/**
+ * The last check of each workflow against the running ComfyUI, held here the
+ * way server test results are held on their rows. Nothing until one is run.
+ */
+type WorkflowCheck = { checking?: boolean; ok?: boolean; problems?: string[]; error?: string };
+const workflowChecks = new Map<string, WorkflowCheck>();
+
+function checkResultFor(name: string): string {
+  const check = workflowChecks.get(name);
+  if (!check) return "";
+  if (check.checking) return `<p class="meta">${t("workflows.checking")}</p>`;
+  if (check.error) return `<p class="error">${esc(check.error)}</p>`;
+  if (check.ok) return `<p class="meta">${t("workflows.checkOk")}</p>`;
+  return (check.problems ?? []).map((problem) => `<p class="error">${esc(problem)}</p>`).join("");
+}
+
+async function runWorkflowCheck(name: string): Promise<void> {
+  workflowChecks.set(name, { checking: true });
+  if (latestState) renderWorkflows(latestState);
+
+  const result = await post<{ ok: boolean; problems: string[] }>("/api/workflows/check", { name });
+  workflowChecks.set(
+    name,
+    result.ok
+      ? { ok: result.data?.ok ?? false, problems: result.data?.problems ?? [] }
+      : { error: result.error ?? t("workflows.checkFailed") },
+  );
+  if (latestState) renderWorkflows(latestState);
+}
+
 function renderWorkflows(state: State): void {
   nodes.workflowDir.textContent = t("workflows.dir", { dir: state.workflowDir });
 
@@ -489,6 +519,11 @@ function renderWorkflows(state: State): void {
           ${active ? `<span class="state"><span class="dot run"></span>${t("workflows.active")}</span>` : ""}
           <span class="spacer"></span>
           ${
+            summary.valid
+              ? `<button type="button" class="ghost" data-check-workflow="${esc(summary.name)}">${t("workflows.check")}</button>`
+              : ""
+          }
+          ${
             active || !summary.valid
               ? ""
               : `<button type="button" class="ghost" data-activate="${esc(summary.name)}">${t("workflows.makeActive")}</button>`
@@ -504,6 +539,7 @@ function renderWorkflows(state: State): void {
         ${head}
         <p class="meta">${t("workflows.nodes", { count: summary.nodeCount ?? 0 })}</p>
         ${slotTags(summary)}
+        ${checkResultFor(summary.name)}
       </div>`;
     })
     .join("");
@@ -1403,6 +1439,12 @@ nodes.uploadForm.addEventListener("submit", async (event) => {
 
 nodes.workflows.addEventListener("click", async (event) => {
   const target = event.target as HTMLElement;
+
+  const check = target.closest<HTMLElement>("[data-check-workflow]")?.dataset["checkWorkflow"];
+  if (check) {
+    void runWorkflowCheck(check);
+    return;
+  }
 
   const activate = target.closest<HTMLElement>("[data-activate]")?.dataset["activate"];
   if (activate) {

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -268,6 +268,13 @@ const STRINGS = {
   },
   "workflows.deleteFailed": { en: "delete failed", ja: "削除できませんでした" },
   "workflows.nodes": { en: "{count} nodes", ja: "ノード {count} 個" },
+  "workflows.check": { en: "Check", ja: "チェック" },
+  "workflows.checking": { en: "checking against ComfyUI…", ja: "ComfyUI と照合中…" },
+  "workflows.checkOk": {
+    en: "every node and choice is available on this ComfyUI",
+    ja: "ノードもモデルも、この ComfyUI にすべて揃っています",
+  },
+  "workflows.checkFailed": { en: "check failed", ja: "チェックできませんでした" },
 
   "slot.detected": { en: "detected", ja: "自動検出" },
   "slot.override": { en: "from .slots.json", ja: ".slots.json での指定" },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -36,6 +36,7 @@ import {
   setActiveWorkflow,
 } from "../workflow";
 import { claimLinkCode, testUpstream } from "../upstream";
+import { checkWorkflow } from "../validate";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -111,6 +112,17 @@ async function handleWorkflowUpload(req: Request): Promise<Response> {
 
     const summary = await saveWorkflowFile(name, await file.text());
     return Response.json({ workflow: summary });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/** Compare one workflow against the running ComfyUI — see `validate.ts`. */
+async function handleWorkflowCheck(req: Request): Promise<Response> {
+  try {
+    const { name } = (await req.json()) as { name?: string };
+    if (!name) return fail("name is required");
+    return Response.json(await checkWorkflow(name));
   } catch (err) {
     return fail(err);
   }
@@ -600,6 +612,7 @@ export function startUi() {
       "/api/workflows/active": { POST: guarded(handleSetActive) },
       "/api/workflows/reload": { POST: guarded(handleReload) },
       "/api/workflows/upload": { POST: guarded(handleWorkflowUpload) },
+      "/api/workflows/check": { POST: guarded(handleWorkflowCheck) },
       "/api/workflows/delete": { POST: guarded(handleWorkflowDelete) },
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,113 @@
+/**
+ * Check a workflow against the ComfyUI it would run on, without running it.
+ *
+ * A workflow that names a model or a custom node this machine does not have
+ * fails only when a run reaches that node — minutes in, after a claim. ComfyUI
+ * already knows everything needed to say so up front: `/object_info` lists
+ * every installed node class, and for each combo input the exact choices on
+ * offer (which is where checkpoints, LoRAs and VAEs live). This compares the
+ * workflow's literal values against that list.
+ *
+ * Inputs the app rewrites at run time — the detected slots, the input image
+ * above all — are left out: their stored value is about to be replaced, so its
+ * absence proves nothing.
+ */
+
+import { COMFY_URL } from "./config";
+import { loadWorkflow } from "./workflow";
+import type { Slot, WorkflowSlots } from "./slots";
+
+type InputSpec = unknown[];
+
+type ObjectInfo = Record<
+  string,
+  {
+    input?: {
+      required?: Record<string, InputSpec>;
+      optional?: Record<string, InputSpec>;
+    };
+  }
+>;
+
+/**
+ * `/object_info` is megabytes and changes only when models or nodes are
+ * installed, so one minute of reuse spares ComfyUI without going stale enough
+ * to mislead anyone.
+ */
+const OBJECT_INFO_TTL_MS = 60_000;
+
+let cached: { at: number; info: ObjectInfo } | null = null;
+
+async function objectInfo(): Promise<ObjectInfo> {
+  if (cached && Date.now() - cached.at < OBJECT_INFO_TTL_MS) return cached.info;
+
+  let res: Response;
+  try {
+    res = await fetch(`${COMFY_URL}/object_info`, { signal: AbortSignal.timeout(30_000) });
+  } catch {
+    throw new Error("ComfyUI is not answering — start it before checking");
+  }
+  if (!res.ok) throw new Error(`ComfyUI /object_info failed: HTTP ${res.status}`);
+
+  const info = (await res.json()) as ObjectInfo;
+  cached = { at: Date.now(), info };
+  return info;
+}
+
+function slotRefs(slots: WorkflowSlots): Set<string> {
+  const refs = new Set<string>();
+  const add = (slot: Slot | null) => {
+    if (slot) refs.add(`${slot.nodeId}:${slot.input}`);
+  };
+  add(slots.image);
+  add(slots.positive);
+  add(slots.negative);
+  add(slots.length);
+  add(slots.frameRate);
+  for (const seed of slots.seed) add(seed);
+  return refs;
+}
+
+export type WorkflowCheck = {
+  ok: boolean;
+  /** Worded server-side, like every other error the UI passes through. */
+  problems: string[];
+  checkedNodes: number;
+};
+
+export async function checkWorkflow(name: string): Promise<WorkflowCheck> {
+  const loaded = await loadWorkflow(name);
+  const info = await objectInfo();
+  const replaced = slotRefs(loaded.slots);
+
+  const problems: string[] = [];
+
+  for (const [nodeId, node] of Object.entries(loaded.workflow)) {
+    const spec = info[node.class_type];
+    if (!spec) {
+      problems.push(`node ${nodeId}: ${node.class_type} is not installed in this ComfyUI`);
+      continue;
+    }
+
+    const inputSpecs = { ...spec.input?.required, ...spec.input?.optional };
+    for (const [inputName, value] of Object.entries(node.inputs)) {
+      // Combo choices are strings; anything else is a number, a link, or text.
+      if (typeof value !== "string") continue;
+      if (replaced.has(`${nodeId}:${inputName}`)) continue;
+
+      const choices = inputSpecs[inputName]?.[0];
+      if (!Array.isArray(choices) || !choices.every((entry) => typeof entry === "string")) {
+        continue;
+      }
+      if (choices.includes(value)) continue;
+
+      problems.push(
+        choices.length === 0
+          ? `node ${nodeId} (${node.class_type}): ${inputName} "${value}" — this ComfyUI has nothing installed to choose from`
+          : `node ${nodeId} (${node.class_type}): ${inputName} "${value}" is not among the ${choices.length} choices this ComfyUI offers`,
+      );
+    }
+  }
+
+  return { ok: problems.length === 0, problems, checkedNodes: Object.keys(loaded.workflow).length };
+}


### PR DESCRIPTION
Closes #26. #32(履歴フィルタ)の上に積んだスタック PR です(7/7)。

必要なモデルやカスタムノードの欠品は、実行して落ちて初めて分かる状態でした。Workflows ページの各行に *Check* ボタンを追加し、実行せずに ComfyUI と照合できるようにしました。

**作り**

- `src/validate.ts` を新設。ComfyUI の `/object_info` を使います。ノード型が存在するか、combo 入力(選択肢が文字列リストのもの — checkpoint / LoRA / VAE / sampler 名などはすべてここ)の値が選択肢にあるか、を全ノードで確認します。
- 実行時に差し替わるスロット(入力画像・プロンプト・シードなど、検出済み + sidecar 上書き込み)は除外します。`LoadImage` の `image` は combo なので、除外しないと「アップロード前の画像がない」という誤検知になります(テストで確認済み)。
- 選択肢が文字列だけでない combo は判定しません(誤検知より見逃しに倒す)。選択肢が 0 件のときは「そもそも何も入っていない」と分けて言います。
- `/object_info` は数 MB あるので 60 秒キャッシュします。ComfyUI が落ちているときは「start it before checking」を返します。
- 問題文はサーバー側の英語文で、他のサーバーエラーと同じくそのまま表示します(行の下に列挙)。結果はサーバーテストと同じく行ごとにページ内で保持します。

**確認したこと(モック `/object_info` での E2E)**

6 ノードのワークフローで: ないチェックポイント / 未インストールノード / 選択肢 0 件の LoRA / ないサンプラー名 の 4 件を列挙し、`LoadImage` の存在しない画像は**検出しない**(スロット除外が効く)こと。問題のないワークフローは `ok: true`。存在しない名前は 400。`bun run check:ci` と `tsc --noEmit` も通っています。