### PR TITLE
feat: land the seven features from the stack on dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ details.
 
 **Generate** runs a workflow by hand: a form on one side, the run history on the
 other. Handy for checking a workflow does what you think before a job server
-starts sending work.
+starts sending work. The history narrows by state and by where the job came
+from, and flips into a gallery of everything the filtered runs produced.
 
 A run in flight carries a bar — the steps ComfyUI has done out of the steps it
 expects, and the node it is on — so a slow workflow can be told from a stuck one.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ done with.
 
 **ComfyUI** points the app at your install — where it is, and optionally the
 command to run there — and starts and stops it, with the tail of its output so
-a wrong command explains itself.
+a wrong command explains itself. A ComfyUI started here that crashes is started
+again on its own; three crashes in a row right after starting read as a broken
+command, so it stops trying and says why in the log.
 
 **Servers** attaches job servers: link one with a code from its own UI, or fill
 a row in by hand; reorder and disable them here too. The order is the priority.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ done with.
 command to run there — and starts and stops it, with the tail of its output so
 a wrong command explains itself. A ComfyUI started here that crashes is started
 again on its own; three crashes in a row right after starting read as a broken
-command, so it stops trying and says why in the log.
+command, so it stops trying and says why in the log. An *Outputs* panel shows
+how much disk ComfyUI's output folder holds, with a button — and an optional
+standing rule — that deletes files older than a chosen number of days.
 
 **Servers** attaches job servers: link one with a code from its own UI, or fill
 a row in by hand; reorder and disable them here too. The order is the priority.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ The Workflows page shows which of these were found, so a workflow that needs hel
 is obvious before you run it. Anything not found is simply not offered — a
 workflow with no `LoadImage` gets no image field.
 
+*Check* on a workflow's row goes further: it asks the running ComfyUI — via
+`/object_info` — whether every node type in the file exists there, and whether
+every file-choosing input (checkpoints, LoRAs, VAEs, …) names something
+actually installed, without running anything. Inputs the app replaces at run
+time, the input image above all, are left out of the check.
+
 Outputs are not detected in advance. Whatever ComfyUI records in its history for
 the run is collected, so images, videos and gifs all work with no configuration.
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,11 +5,13 @@ import {
   AUTO_UPDATE,
   COMFY_URL,
   HEARTBEAT_INTERVAL_MS,
+  JOB_RETRIES,
   POLL_INTERVAL_MS,
+  RETRY_DELAY_MS,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./config";
 import { pushEvent } from "./events";
-import { completeJob, failJob, markQueued, startJob } from "./jobs";
+import { completeJob, failJob, markQueued, noteAttempt, startJob } from "./jobs";
 import { latestStatus, refreshStatus } from "./status";
 import { RESTART_EXIT_CODE, remoteHasUpdate } from "./updater";
 import { loadSettings } from "./settings";
@@ -113,39 +115,64 @@ async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
     workflow: workflowName,
   });
 
-  try {
-    let imageFilename: string | undefined;
-    if (claimed.sourceImageBase64) {
-      const contentType = claimed.sourceImageContentType || "image/png";
-      const ext = contentType.split("/")[1] ?? "png";
-      imageFilename = await uploadImage(
-        COMFY_URL,
-        `input_${claimed.jobId}.${ext}`,
-        contentType,
-        Buffer.from(claimed.sourceImageBase64, "base64"),
+  // A transient failure — a network blip, ComfyUI mid-restart — gets retried
+  // on this machine before the job server hears anything: the job is claimed
+  // and would not be handed out again anyway. Only claimed jobs retry; a run
+  // from the UI has someone watching it, who would not expect a quiet rerun.
+  const tries = 1 + JOB_RETRIES;
+
+  for (let attempt = 1; ; attempt++) {
+    if (attempt > 1) noteAttempt(job, attempt);
+
+    try {
+      let imageFilename: string | undefined;
+      if (claimed.sourceImageBase64) {
+        const contentType = claimed.sourceImageContentType || "image/png";
+        const ext = contentType.split("/")[1] ?? "png";
+        // The name repeats across attempts and the upload overwrites, so a
+        // retry cannot litter ComfyUI's input folder.
+        imageFilename = await uploadImage(
+          COMFY_URL,
+          `input_${claimed.jobId}.${ext}`,
+          contentType,
+          Buffer.from(claimed.sourceImageBase64, "base64"),
+        );
+        console.log(`[worker] uploaded input image → ${imageFilename}`);
+      }
+
+      const outputs = await runWorkflow(
+        workflowName,
+        { ...claimed.params, imageFilename },
+        (promptId) => markQueued(job, promptId),
       );
-      console.log(`[worker] uploaded input image → ${imageFilename}`);
+
+      // Upstreams expect a single artefact. Video workflows also emit preview
+      // images, so prefer a playable file over whatever happens to come first.
+      const primary = outputs.find((output) => output.kind === "video") ?? outputs[0]!;
+      await uploadResult(server, claimed.jobId, primary.url);
+      await reportComplete(server, claimed.jobId);
+
+      completeJob(job, outputs);
+      console.log(`[worker] job ${claimed.jobId} completed`);
+      return;
+    } catch (err) {
+      const reason = message(err);
+
+      if (attempt < tries && running) {
+        console.error(
+          `[worker] job ${claimed.jobId} attempt ${attempt}/${tries} failed: ${reason}` +
+            ` — retrying in ${Math.round(RETRY_DELAY_MS / 1000)} s`,
+        );
+        await idle(RETRY_DELAY_MS);
+        // The agent was stopped mid-wait; report rather than run on regardless.
+        if (running) continue;
+      }
+
+      console.error(`[worker] job ${claimed.jobId} failed: ${reason}`);
+      failJob(job, reason);
+      await reportFailure(server, claimed.jobId, reason);
+      return;
     }
-
-    const outputs = await runWorkflow(
-      workflowName,
-      { ...claimed.params, imageFilename },
-      (promptId) => markQueued(job, promptId),
-    );
-
-    // Upstreams expect a single artefact. Video workflows also emit preview
-    // images, so prefer a playable file over whatever happens to come first.
-    const primary = outputs.find((output) => output.kind === "video") ?? outputs[0]!;
-    await uploadResult(server, claimed.jobId, primary.url);
-    await reportComplete(server, claimed.jobId);
-
-    completeJob(job, outputs);
-    console.log(`[worker] job ${claimed.jobId} completed`);
-  } catch (err) {
-    const reason = message(err);
-    console.error(`[worker] job ${claimed.jobId} failed: ${reason}`);
-    failJob(job, reason);
-    await reportFailure(server, claimed.jobId, reason);
   }
 }
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -8,6 +8,7 @@ import {
   POLL_INTERVAL_MS,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./config";
+import { pushEvent } from "./events";
 import { completeJob, failJob, markQueued, startJob } from "./jobs";
 import { latestStatus, refreshStatus } from "./status";
 import { RESTART_EXIT_CODE, remoteHasUpdate } from "./updater";
@@ -60,12 +61,17 @@ async function sendHeartbeats() {
 
   await Promise.all(
     upstreams.map(async (server) => {
+      // What the last beat said, so only a change of state is announced.
+      const was = heartbeats.get(server.name)?.ok;
+
       const ack = await sendHeartbeat(server, status);
       if (!ack) {
         heartbeats.set(server.name, { ok: false, at: Date.now() });
+        if (was !== false) pushEvent("upstream-down", { server: server.name });
         return;
       }
       heartbeats.set(server.name, { ok: true, at: Date.now(), pendingJobs: ack.pendingJobs });
+      if (was === false) pushEvent("upstream-up", { server: server.name });
       const backlog =
         ack.pendingJobs === undefined ? "" : ` | upstream queue: ${ack.pendingJobs} waiting`;
       console.log(

--- a/src/comfy-process.ts
+++ b/src/comfy-process.ts
@@ -11,6 +11,10 @@
  * request can only say "start" or "stop" — it cannot say what to run. That
  * still means anyone who can reach the management UI can run the configured
  * command, which is why the UI binds to 127.0.0.1 unless you change it.
+ *
+ * A managed child that dies without being asked is restarted (see the watchdog
+ * constants below); only `stopComfy` — the Stop buttons and the Stopped mode —
+ * counts as being asked.
  */
 
 import { existsSync } from "node:fs";
@@ -33,10 +37,27 @@ export type ComfyProcessState = {
 
 const LOG_LINES = 40;
 
+/**
+ * The watchdog. A machine that serves jobs unattended is only as reliable as
+ * the ComfyUI under it, so a managed child that dies without being asked is
+ * started again. A child that keeps dying moments after starting is a broken
+ * command, not a hiccup — after three of those in a row it stops trying, and
+ * the log holds the reason.
+ */
+const RESTART_DELAY_MS = 5000;
+const FAST_FAIL_MS = 60_000;
+const MAX_FAST_FAILS = 3;
+
 let child: Bun.Subprocess | null = null;
 let startedAt: number | null = null;
 let lastError: string | null = null;
 const log: string[] = [];
+
+/** True between a successful start and a requested stop: "keep it running". */
+let wanted = false;
+let restartTimer: ReturnType<typeof setTimeout> | null = null;
+/** Consecutive deaths within {@link FAST_FAIL_MS} of starting. */
+let fastFails = 0;
 
 function note(line: string): void {
   for (const part of line.split("\n")) {
@@ -115,22 +136,30 @@ export async function startComfy(): Promise<void> {
 
   log.length = 0;
   lastError = null;
+  fastFails = 0;
+  wanted = true;
+  launch(command, settings.comfyDir);
+}
+
+function launch(command: string[], dir: string): void {
   note(`$ ${command.join(" ")}`);
 
   const spawned = Bun.spawn(command, {
-    cwd: settings.comfyDir,
+    cwd: dir,
     stdout: "pipe",
     stderr: "pipe",
     onExit(_proc, exitCode, signalCode) {
       note(`— exited (code ${exitCode ?? "null"}${signalCode ? `, ${signalCode}` : ""})`);
+      if (child !== spawned) return;
+
+      const uptime = Date.now() - (startedAt ?? Date.now());
+      child = null;
+      startedAt = null;
       // A non-zero exit with nothing asked of it is a failure worth surfacing.
-      if (child === spawned && exitCode !== 0 && signalCode === null) {
+      if (exitCode !== 0 && signalCode === null) {
         lastError = `ComfyUI exited with code ${exitCode}`;
       }
-      if (child === spawned) {
-        child = null;
-        startedAt = null;
-      }
+      maybeRestart(uptime);
     },
   });
 
@@ -139,6 +168,49 @@ export async function startComfy(): Promise<void> {
 
   void drain(spawned.stdout);
   void drain(spawned.stderr);
+}
+
+/** Called with how long the child lived, after every exit nobody asked for. */
+function maybeRestart(uptimeMs: number): void {
+  if (!wanted) return;
+
+  // A death after a long run gets a fresh allowance; one right after starting
+  // spends it.
+  fastFails = uptimeMs < FAST_FAIL_MS ? fastFails + 1 : 1;
+
+  if (fastFails > MAX_FAST_FAILS) {
+    wanted = false;
+    lastError = "ComfyUI keeps crashing right after starting — not restarting, check the log";
+    note(`— ${lastError}`);
+    return;
+  }
+
+  note(`— restarting in ${RESTART_DELAY_MS / 1000} s (crash ${fastFails}/${MAX_FAST_FAILS})`);
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    void restart();
+  }, RESTART_DELAY_MS);
+}
+
+/**
+ * The automatic path back up. Unlike {@link startComfy} it keeps the log, so
+ * the crash that caused it stays readable, and it re-reads the settings so a
+ * directory fixed in the meantime is what gets run.
+ */
+async function restart(): Promise<void> {
+  // Someone pressed Stop during the delay, or Start beat the timer to it.
+  if (!wanted || child) return;
+
+  const settings = await loadSettings();
+  const command = resolveCommand(settings.comfyDir, settings.comfyCommand);
+  if (!settings.comfyDir || !existsSync(settings.comfyDir) || command.length === 0) {
+    wanted = false;
+    lastError = "cannot restart ComfyUI — the directory or command is gone";
+    note(`— ${lastError}`);
+    return;
+  }
+
+  launch(command, settings.comfyDir);
 }
 
 async function drain(stream: ReadableStream<Uint8Array> | number | undefined): Promise<void> {
@@ -152,6 +224,13 @@ async function drain(stream: ReadableStream<Uint8Array> | number | undefined): P
  * two; a model still loading can take longer than anyone wants to wait.
  */
 export async function stopComfy(): Promise<void> {
+  // Asked to stop, so an exit is no longer something to undo.
+  wanted = false;
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+
   const running = child;
   if (!running) return;
 

--- a/src/comfy-process.ts
+++ b/src/comfy-process.ts
@@ -19,6 +19,7 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { pushEvent } from "./events";
 import { loadSettings } from "./settings";
 
 export type ComfyProcessState = {
@@ -182,10 +183,12 @@ function maybeRestart(uptimeMs: number): void {
     wanted = false;
     lastError = "ComfyUI keeps crashing right after starting — not restarting, check the log";
     note(`— ${lastError}`);
+    pushEvent("comfy-gave-up");
     return;
   }
 
   note(`— restarting in ${RESTART_DELAY_MS / 1000} s (crash ${fastFails}/${MAX_FAST_FAILS})`);
+  pushEvent("comfy-crashed");
   restartTimer = setTimeout(() => {
     restartTimer = null;
     void restart();

--- a/src/comfy.ts
+++ b/src/comfy.ts
@@ -1,13 +1,36 @@
 import { CLIENT_ID } from "./progress";
 import type { ApiWorkflow } from "./slots";
-import type { ComfyStatusResult, OutputKind, RunOutput } from "./types";
+import type { ComfyStatusResult, GpuStatus, OutputKind, RunOutput } from "./types";
 
 type ComfyQueueResponse = {
   queue_running?: unknown[];
   queue_pending?: unknown[];
 };
 
-/** Reachability plus queue depth, used for heartbeats and the UI header. */
+type SystemStats = {
+  devices?: {
+    name?: string;
+    type?: string;
+    vram_total?: number;
+    vram_free?: number;
+  }[];
+};
+
+/** The first device that is not the CPU — the one the models actually load on. */
+function firstGpu(stats: SystemStats): GpuStatus | null {
+  const device = stats.devices?.find((entry) => entry.type !== "cpu");
+  if (
+    !device ||
+    typeof device.vram_total !== "number" ||
+    typeof device.vram_free !== "number" ||
+    device.vram_total <= 0
+  ) {
+    return null;
+  }
+  return { name: device.name ?? "GPU", vramTotal: device.vram_total, vramFree: device.vram_free };
+}
+
+/** Reachability, queue depth and VRAM, used for heartbeats and the UI header. */
 export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
   try {
     const signal = AbortSignal.timeout(5000);
@@ -17,9 +40,10 @@ export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
     ]);
 
     if (!statsRes.ok || !queueRes.ok) {
-      return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0 };
+      return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0, gpu: null };
     }
 
+    const stats = (await statsRes.json()) as SystemStats;
     const queue = (await queueRes.json()) as ComfyQueueResponse;
     const queueRunning = queue.queue_running?.length ?? 0;
     const queuePending = queue.queue_pending?.length ?? 0;
@@ -28,9 +52,10 @@ export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
       comfyStatus: queueRunning > 0 ? "busy" : "available",
       queueRunning,
       queuePending,
+      gpu: firstGpu(stats),
     };
   } catch {
-    return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0 };
+    return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0, gpu: null };
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,14 @@ export const HEARTBEAT_INTERVAL_MS = Number(process.env.HEARTBEAT_INTERVAL_MS ??
 /** How long a single ComfyUI run may take before it is abandoned. */
 export const JOB_TIMEOUT_MS = Number(process.env.JOB_TIMEOUT_MS ?? "600000");
 
+/**
+ * Extra tries an upstream job gets on this machine before its failure is
+ * reported. A transient failure — a network blip, ComfyUI mid-restart — is
+ * cheaper to retry here than to bounce back through the job server.
+ */
+export const JOB_RETRIES = Number(process.env.JOB_RETRIES ?? "2");
+export const RETRY_DELAY_MS = Number(process.env.RETRY_DELAY_MS ?? "10000");
+
 export const AUTO_UPDATE = (process.env.AUTO_UPDATE ?? "false") !== "false";
 export const UPDATE_CHECK_INTERVAL_MS = Number(process.env.UPDATE_CHECK_INTERVAL_MS ?? "60000");
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,7 +14,8 @@ export type UiEventKind =
   | "upstream-down"
   | "upstream-up"
   | "comfy-crashed"
-  | "comfy-gave-up";
+  | "comfy-gave-up"
+  | "outputs-trimmed";
 
 export type UiEvent = {
   id: number;

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,41 @@
+/**
+ * Things worth telling a person about, kept as a small ring the UI reads from
+ * `/api/state` and turns into OS notifications.
+ *
+ * The server records facts — kind and parameters — and whoever displays them
+ * writes the sentence, in the reader's language. Ids are time-based so a
+ * watcher's "seen up to here" survives this process restarting; the ring is
+ * short because anything older is history, and history is what the log and the
+ * Runs page are for.
+ */
+
+export type UiEventKind =
+  | "job-failed"
+  | "upstream-down"
+  | "upstream-up"
+  | "comfy-crashed"
+  | "comfy-gave-up";
+
+export type UiEvent = {
+  id: number;
+  at: number;
+  kind: UiEventKind;
+  /** What the event is about — workflow, server name, error — for the message. */
+  params: Record<string, string>;
+};
+
+const MAX_EVENTS = 20;
+
+const events: UiEvent[] = [];
+let nextId = 0;
+
+export function pushEvent(kind: UiEventKind, params: Record<string, string> = {}): void {
+  // Monotonic and larger than any id a previous run handed out.
+  nextId = Math.max(nextId + 1, Date.now());
+  events.push({ id: nextId, at: Date.now(), kind, params });
+  if (events.length > MAX_EVENTS) events.splice(0, events.length - MAX_EVENTS);
+}
+
+export function listEvents(): UiEvent[] {
+  return events;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { startAgent, stopAgent } from "./agent";
 import { startComfyWatch, stopComfy } from "./comfy-process";
 import { COMFY_URL, DATA_DIR, UI_ENABLED, WORKFLOW_DIR } from "./config";
 import { loadJobs } from "./jobs";
+import { startOutputWatch } from "./outputs";
 import { startProgressWatch, stopProgressWatch } from "./progress";
 import { loadSettings } from "./settings";
 import { startStatusPolling } from "./status";
@@ -37,6 +38,7 @@ if (names.length === 0) {
 
 const statusTimer = startStatusPolling(STATUS_POLL_MS);
 const comfyWatch = startComfyWatch();
+const outputWatch = startOutputWatch();
 startProgressWatch();
 
 if (UI_ENABLED) {
@@ -56,6 +58,7 @@ function shutdown() {
   stopAgent();
   clearInterval(statusTimer);
   clearInterval(comfyWatch);
+  clearInterval(outputWatch);
   stopProgressWatch();
   void stopComfy();
   process.exit(0);

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -9,6 +9,7 @@
 
 import { readFile, writeFile } from "node:fs/promises";
 import { JOBS_FILE } from "./config";
+import { pushEvent } from "./events";
 import type { JobRecord, JobSource, RunOutput } from "./types";
 
 const MAX_JOBS = 200;
@@ -83,6 +84,8 @@ export function failJob(job: JobRecord, error: string): void {
   job.error = error;
   job.finishedAt = Date.now();
   persist();
+  // Cut for a notification body, not for the record: `job.error` keeps it all.
+  pushEvent("job-failed", { workflow: job.workflow, error: error.slice(0, 200) });
 }
 
 export function listJobs(): JobRecord[] {

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -72,6 +72,12 @@ export function markQueued(job: JobRecord, promptId: string): void {
   persist();
 }
 
+/** Records that the job is on its `attempt`-th try, so the UI can say so. */
+export function noteAttempt(job: JobRecord, attempt: number): void {
+  job.attempts = attempt;
+  persist();
+}
+
 export function completeJob(job: JobRecord, outputs: RunOutput[]): void {
   job.state = "succeeded";
   job.outputs = outputs;

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -1,0 +1,144 @@
+/**
+ * ComfyUI's output folder, watched and trimmed.
+ *
+ * Video workflows fill the disk quietly — nothing in ComfyUI ever deletes an
+ * output. This keeps a cheap running total (files and bytes) for the UI, and
+ * deletes files older than a chosen age: on demand from a button, and on a
+ * timer when `outputCleanupDays` is set.
+ *
+ * Only files under the output directory are ever touched, and directories are
+ * left in place. The scan is cached and redone on a slow timer rather than per
+ * request — the UI polls every two seconds, and a large folder should not be
+ * walked at that pace.
+ */
+
+import { existsSync } from "node:fs";
+import { readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { pushEvent } from "./events";
+import { loadSettings } from "./settings";
+
+const SCAN_INTERVAL_MS = 10 * 60_000;
+const DAY_MS = 86_400_000;
+
+export type OutputsSnapshot = {
+  dir: string;
+  files: number;
+  bytes: number;
+  scannedAt: number;
+};
+
+let snapshot: OutputsSnapshot | null = null;
+
+/**
+ * Where ComfyUI writes its outputs, mirroring how `resolveCommand` reads the
+ * directory: the portable bundle keeps ComfyUI one level down.
+ */
+export function outputDirFor(comfyDir: string): string | null {
+  if (!comfyDir) return null;
+  const portable = join(comfyDir, "ComfyUI", "output");
+  if (existsSync(portable)) return portable;
+  const plain = join(comfyDir, "output");
+  return existsSync(plain) ? plain : null;
+}
+
+async function walk(
+  dir: string,
+  visit: (path: string, size: number, mtimeMs: number) => void,
+): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(path, visit);
+    } else if (entry.isFile()) {
+      const stats = await stat(path).catch(() => null);
+      if (stats) visit(path, stats.size, stats.mtimeMs);
+    }
+  }
+}
+
+export function outputsSnapshot(): OutputsSnapshot | null {
+  return snapshot;
+}
+
+export async function rescanOutputs(): Promise<OutputsSnapshot | null> {
+  const dir = outputDirFor((await loadSettings()).comfyDir);
+  if (!dir) {
+    snapshot = null;
+    return null;
+  }
+
+  let files = 0;
+  let bytes = 0;
+  await walk(dir, (_path, size) => {
+    files += 1;
+    bytes += size;
+  });
+
+  snapshot = { dir, files, bytes, scannedAt: Date.now() };
+  return snapshot;
+}
+
+/** "3.2 GB" or "410 MB" — for logs and notifications, not for the record. */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+/**
+ * Delete every file older than `days` under the output folder. A file that
+ * refuses to go — held open by a player, say — is skipped, not fatal: the next
+ * sweep gets another chance at it.
+ */
+export async function trimOutputs(
+  days: number,
+): Promise<{ removedFiles: number; removedBytes: number }> {
+  const dir = outputDirFor((await loadSettings()).comfyDir);
+  if (!dir) throw new Error("no output folder found — set the ComfyUI directory first");
+
+  const cutoff = Date.now() - days * DAY_MS;
+  const doomed: { path: string; size: number }[] = [];
+  await walk(dir, (path, size, mtimeMs) => {
+    if (mtimeMs < cutoff) doomed.push({ path, size });
+  });
+
+  let removedFiles = 0;
+  let removedBytes = 0;
+  for (const file of doomed) {
+    try {
+      await rm(file.path);
+      removedFiles += 1;
+      removedBytes += file.size;
+    } catch {
+      // Skipped this sweep; it stays in the count the rescan reports.
+    }
+  }
+
+  await rescanOutputs();
+  return { removedFiles, removedBytes };
+}
+
+/** One pass of the timer: apply the stored rule, or just refresh the count. */
+async function sweep(): Promise<void> {
+  const settings = await loadSettings();
+
+  if (settings.outputCleanupDays > 0 && outputDirFor(settings.comfyDir)) {
+    const { removedFiles, removedBytes } = await trimOutputs(settings.outputCleanupDays);
+    if (removedFiles > 0) {
+      console.log(`[outputs] removed ${removedFiles} file(s), ${formatBytes(removedBytes)}`);
+      pushEvent("outputs-trimmed", {
+        files: String(removedFiles),
+        size: formatBytes(removedBytes),
+      });
+    }
+    return; // trimOutputs rescanned already
+  }
+
+  await rescanOutputs();
+}
+
+export function startOutputWatch(): ReturnType<typeof setInterval> {
+  void sweep();
+  return setInterval(() => void sweep(), SCAN_INTERVAL_MS);
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -88,6 +88,11 @@ export type Settings = {
    * quietly start claiming again.
    */
   pauseUntil: number | null;
+  /**
+   * Outputs older than this many days are deleted by the sweep in
+   * `outputs.ts`. `0` — the default — means never delete anything.
+   */
+  outputCleanupDays: number;
   desktop: DesktopSettings;
 };
 
@@ -99,6 +104,7 @@ const EMPTY: Settings = {
   mode: "accepting",
   schedule: EMPTY_SCHEDULE,
   pauseUntil: null,
+  outputCleanupDays: 0,
   desktop: { autostart: false, closeAction: "tray" },
 };
 
@@ -170,6 +176,13 @@ function normaliseSchedule(raw: unknown): AcceptSchedule {
   };
 }
 
+/** Anything a day count cannot be — negative, NaN, absent — means "off". */
+export function normaliseCleanupDays(raw: unknown): number {
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 1
+    ? Math.min(3650, Math.floor(raw))
+    : 0;
+}
+
 function normaliseDesktop(raw: unknown): DesktopSettings {
   const value = (raw ?? {}) as Partial<DesktopSettings>;
   return {
@@ -192,6 +205,7 @@ function normalise(raw: unknown): Settings {
     mode: normaliseMode(value),
     schedule: normaliseSchedule(value.schedule),
     pauseUntil: typeof value.pauseUntil === "number" ? value.pauseUntil : null,
+    outputCleanupDays: normaliseCleanupDays(value.outputCleanupDays),
     desktop: normaliseDesktop(value.desktop),
   };
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -10,6 +10,7 @@ let latest: ComfyStatusResult = {
   comfyStatus: "unavailable",
   queueRunning: 0,
   queuePending: 0,
+  gpu: null,
 };
 let checkedAt = 0;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,8 @@ export type JobRecord = {
   promptId?: string;
   outputs?: RunOutput[];
   error?: string;
+  /** Tries this job has had on this machine; absent means the first. */
+  attempts?: number;
   /**
    * The process died while this job was running. Flagged rather than left to
    * `error` alone so the UI can say it in the reader's own language.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,22 @@
 export type ComfyStatus = "available" | "busy" | "unavailable";
 
+/**
+ * The GPU as ComfyUI reports it, in bytes. Read through ComfyUI rather than
+ * from this machine, so a remote `COMFY_URL` shows the GPU actually doing the
+ * work.
+ */
+export type GpuStatus = {
+  name: string;
+  vramTotal: number;
+  vramFree: number;
+};
+
 export type ComfyStatusResult = {
   comfyStatus: ComfyStatus;
   queueRunning: number;
   queuePending: number;
+  /** `null` when ComfyUI is unreachable or reported no GPU device. */
+  gpu: GpuStatus | null;
 };
 
 export type OutputKind = "image" | "video" | "audio" | "file";

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -472,6 +472,36 @@ function slotTags(summary: WorkflowSummary): string {
   return `<div class="slots">${tags.join("")}</div>`;
 }
 
+/**
+ * The last check of each workflow against the running ComfyUI, held here the
+ * way server test results are held on their rows. Nothing until one is run.
+ */
+type WorkflowCheck = { checking?: boolean; ok?: boolean; problems?: string[]; error?: string };
+const workflowChecks = new Map<string, WorkflowCheck>();
+
+function checkResultFor(name: string): string {
+  const check = workflowChecks.get(name);
+  if (!check) return "";
+  if (check.checking) return `<p class="meta">${t("workflows.checking")}</p>`;
+  if (check.error) return `<p class="error">${esc(check.error)}</p>`;
+  if (check.ok) return `<p class="meta">${t("workflows.checkOk")}</p>`;
+  return (check.problems ?? []).map((problem) => `<p class="error">${esc(problem)}</p>`).join("");
+}
+
+async function runWorkflowCheck(name: string): Promise<void> {
+  workflowChecks.set(name, { checking: true });
+  if (latestState) renderWorkflows(latestState);
+
+  const result = await post<{ ok: boolean; problems: string[] }>("/api/workflows/check", { name });
+  workflowChecks.set(
+    name,
+    result.ok
+      ? { ok: result.data?.ok ?? false, problems: result.data?.problems ?? [] }
+      : { error: result.error ?? t("workflows.checkFailed") },
+  );
+  if (latestState) renderWorkflows(latestState);
+}
+
 function renderWorkflows(state: State): void {
   nodes.workflowDir.textContent = t("workflows.dir", { dir: state.workflowDir });
 
@@ -489,6 +519,11 @@ function renderWorkflows(state: State): void {
           ${active ? `<span class="state"><span class="dot run"></span>${t("workflows.active")}</span>` : ""}
           <span class="spacer"></span>
           ${
+            summary.valid
+              ? `<button type="button" class="ghost" data-check-workflow="${esc(summary.name)}">${t("workflows.check")}</button>`
+              : ""
+          }
+          ${
             active || !summary.valid
               ? ""
               : `<button type="button" class="ghost" data-activate="${esc(summary.name)}">${t("workflows.makeActive")}</button>`
@@ -504,6 +539,7 @@ function renderWorkflows(state: State): void {
         ${head}
         <p class="meta">${t("workflows.nodes", { count: summary.nodeCount ?? 0 })}</p>
         ${slotTags(summary)}
+        ${checkResultFor(summary.name)}
       </div>`;
     })
     .join("");
@@ -1403,6 +1439,12 @@ nodes.uploadForm.addEventListener("submit", async (event) => {
 
 nodes.workflows.addEventListener("click", async (event) => {
   const target = event.target as HTMLElement;
+
+  const check = target.closest<HTMLElement>("[data-check-workflow]")?.dataset["checkWorkflow"];
+  if (check) {
+    void runWorkflowCheck(check);
+    return;
+  }
 
   const activate = target.closest<HTMLElement>("[data-activate]")?.dataset["activate"];
   if (activate) {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -7,7 +7,7 @@
  * into is left alone until they save or revert.
  */
 
-import { LANGS, lang, locale, onLangChange, setLang, t } from "./i18n";
+import { LANGS, isKey, lang, locale, onLangChange, setLang, t } from "./i18n";
 import type { Key, Lang } from "./i18n";
 
 type RunMode = "accepting" | "local" | "paused";
@@ -114,6 +114,8 @@ type State = {
   } | null;
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
+  /** Ring of recent server-side events, oldest first; ids only ever grow. */
+  events: { id: number; at: number; kind: string; params: Record<string, string> }[];
 };
 
 const POLL_MS = 2000;
@@ -170,6 +172,8 @@ const nodes = {
   acceptNote: el("accept-note"),
   desktopAutostart: el<HTMLInputElement>("desktop-autostart"),
   desktopNote: el("desktop-note"),
+  notifyEnabled: el<HTMLInputElement>("notify-enabled"),
+  notifyNote: el("notify-note"),
 };
 
 function esc(value: unknown): string {
@@ -776,7 +780,10 @@ function openPopover(target: Popover | null): void {
     popover.panel.hidden = !open;
     popover.button.setAttribute("aria-expanded", String(open));
   }
-  if (target !== DESKTOP_POPOVER) setNote(nodes.desktopNote, "");
+  if (target !== DESKTOP_POPOVER) {
+    setNote(nodes.desktopNote, "");
+    setNote(nodes.notifyNote, "");
+  }
   if (target !== MODE_POPOVER) setNote(nodes.modeNote, "");
 }
 
@@ -901,6 +908,111 @@ async function saveDesktop(path: string, body: unknown): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Notifications — server-side events turned into OS notifications
+// ---------------------------------------------------------------------------
+
+const NOTIFY_KEY = "notify";
+const NOTIFY_SEEN_KEY = "notify-seen";
+
+function notifyOn(): boolean {
+  try {
+    return localStorage.getItem(NOTIFY_KEY) === "on";
+  } catch {
+    return false;
+  }
+}
+
+function storeNotify(on: boolean): void {
+  try {
+    localStorage.setItem(NOTIFY_KEY, on ? "on" : "off");
+  } catch {
+    // Private mode — the choice lasts for this tab only.
+  }
+}
+
+let notifySeen = (() => {
+  try {
+    return Number(localStorage.getItem(NOTIFY_SEEN_KEY) ?? "0") || 0;
+  } catch {
+    return 0;
+  }
+})();
+
+/** False until the first poll: its backlog predates this page, so it is noise. */
+let notifyPrimed = false;
+
+function rememberSeen(id: number): void {
+  notifySeen = id;
+  try {
+    localStorage.setItem(NOTIFY_SEEN_KEY, String(id));
+  } catch {
+    // Private mode — an old event may notify again after a reload.
+  }
+}
+
+function notifyGranted(): boolean {
+  return "Notification" in window && Notification.permission === "granted";
+}
+
+function syncNotify(state: State): void {
+  const newest = state.events.at(-1)?.id ?? 0;
+
+  if (!notifyPrimed) {
+    notifyPrimed = true;
+    if (newest > notifySeen) rememberSeen(newest);
+    return;
+  }
+  if (newest <= notifySeen) return;
+
+  const fresh = state.events.filter((event) => event.id > notifySeen);
+  // Advanced even while notifications are off, so turning them on later does
+  // not replay history.
+  rememberSeen(newest);
+  if (!notifyOn() || !notifyGranted()) return;
+
+  for (const event of fresh) {
+    const key = `notify.${event.kind}`;
+    // A kind this page has no words for is skipped rather than crashed on —
+    // the server can be newer than a cached page.
+    if (!isKey(key)) continue;
+    try {
+      new Notification(t(key, event.params), {
+        body: event.params["error"] ?? "",
+        tag: `dcs-${event.id}`,
+      });
+    } catch {
+      // The permission can be revoked between polls; nothing to be done.
+    }
+  }
+}
+
+/**
+ * Turning it on asks the browser there and then, so the permission prompt is
+ * the answer to a click rather than appearing out of nowhere.
+ */
+async function setNotify(on: boolean): Promise<void> {
+  if (!on) {
+    storeNotify(false);
+    setNote(nodes.notifyNote, "");
+    return;
+  }
+  if (!("Notification" in window)) {
+    nodes.notifyEnabled.checked = false;
+    setNote(nodes.notifyNote, t("notify.unsupported"), true);
+    return;
+  }
+  const permission =
+    Notification.permission === "granted" ? "granted" : await Notification.requestPermission();
+  if (permission !== "granted") {
+    nodes.notifyEnabled.checked = false;
+    setNote(nodes.notifyNote, t("notify.blocked"), true);
+    return;
+  }
+  storeNotify(true);
+  setNote(nodes.notifyNote, "");
+}
+
+// ---------------------------------------------------------------------------
 // Run form
 // ---------------------------------------------------------------------------
 
@@ -970,6 +1082,7 @@ function render(state: State): void {
   syncMode(state);
   syncAccepting(state);
   syncDesktop(state);
+  syncNotify(state);
   syncForm(state);
 }
 
@@ -1385,6 +1498,8 @@ nodes.desktopAutostart.addEventListener("change", () => {
   void saveDesktop("/api/desktop", { autostart: nodes.desktopAutostart.checked });
 });
 
+nodes.notifyEnabled.addEventListener("change", () => void setNotify(nodes.notifyEnabled.checked));
+
 nodes.desktopPanel.addEventListener("click", (event) => {
   const choice = (event.target as HTMLElement).closest<HTMLElement>("[data-close-action]")?.dataset[
     "closeAction"
@@ -1423,6 +1538,9 @@ setInterval(() => {
     if (Number.isFinite(started)) span.textContent = formatDuration(Date.now() - started);
   }
 }, 1000);
+
+// A permission revoked since last time reads as "off", matching what happens.
+nodes.notifyEnabled.checked = notifyOn() && notifyGranted();
 
 applyTheme(currentTheme());
 setLang(lang());

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -51,6 +51,8 @@ type JobRecord = {
   promptId?: string;
   outputs?: RunOutput[];
   error?: string;
+  /** Tries this job has had on this machine; absent means the first. */
+  attempts?: number;
   interrupted?: boolean;
 };
 
@@ -735,6 +737,8 @@ function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress
     </div>
     <p class="meta">${formatTime(job.startedAt)} · ${timing}${origin}${
       job.promptId ? ` · ${t("jobs.prompt", { id: esc(job.promptId.slice(0, 8)) })}` : ""
+    }${
+      job.attempts && job.attempts > 1 ? ` · ${t("jobs.attempt", { count: job.attempts })}` : ""
     }</p>
     ${progressBar(job, progress)}
     ${jobError(job)}

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -760,12 +760,62 @@ function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress
   </div>`;
 }
 
+// Page-local: the history itself is what it is, only its reading is chosen.
+type JobStateFilter = "all" | JobRecord["state"];
+type JobSourceFilter = "all" | JobRecord["source"];
+type JobsView = "list" | "gallery";
+
+let jobStateFilter: JobStateFilter = "all";
+let jobSourceFilter: JobSourceFilter = "all";
+let jobsView: JobsView = "list";
+
+/**
+ * Every image and video the filtered runs produced, newest first, each cell
+ * opening (or playing) the file itself. Failures and files that are neither
+ * are the list view's business.
+ */
+function galleryHtml(jobs: JobRecord[]): string {
+  const cells: string[] = [];
+  for (const job of jobs) {
+    for (const output of job.outputs ?? []) {
+      const url = outputUrl(output);
+      const name = esc(output.filename);
+      const caption = `${esc(job.workflow)} · ${formatTime(job.startedAt)}`;
+      if (output.kind === "image") {
+        cells.push(
+          `<a class="cell" href="${url}" target="_blank" rel="noreferrer" title="${caption}">` +
+            `<img src="${url}" alt="${name}" loading="lazy" /></a>`,
+        );
+      } else if (output.kind === "video") {
+        cells.push(
+          `<div class="cell" title="${caption}">` +
+            `<video src="${url}" controls preload="metadata" title="${name}"></video></div>`,
+        );
+      }
+    }
+  }
+  if (cells.length === 0) return `<p class="empty">${t("jobs.noMedia")}</p>`;
+  return `<div class="gallery">${cells.join("")}</div>`;
+}
+
 function renderJobs(state: State): void {
-  if (state.jobs.length === 0) {
-    renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${t("jobs.empty")}</p>`);
+  const jobs = state.jobs.filter(
+    (job) =>
+      (jobStateFilter === "all" || job.state === jobStateFilter) &&
+      (jobSourceFilter === "all" || job.source === jobSourceFilter),
+  );
+
+  if (jobsView === "gallery") {
+    renderIfChanged(nodes.jobs, "jobs", galleryHtml(jobs));
     return;
   }
-  const html = state.jobs.map((job) => jobEntry(job, true, state.progress)).join("");
+  if (jobs.length === 0) {
+    // An empty history and a filter that matched nothing read differently.
+    const text = state.jobs.length === 0 ? t("jobs.empty") : t("jobs.noMatch");
+    renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${text}</p>`);
+    return;
+  }
+  const html = jobs.map((job) => jobEntry(job, true, state.progress)).join("");
   renderIfChanged(nodes.jobs, "jobs", `<div class="ledger">${html}</div>`);
 }
 
@@ -1492,6 +1542,44 @@ nodes.jobs.addEventListener("click", async (event) => {
   lastHtml.delete("jobs");
   void poll();
 });
+
+function syncJobFilterButtons(): void {
+  const groups: [attribute: string, current: string][] = [
+    ["data-job-state", jobStateFilter],
+    ["data-job-source", jobSourceFilter],
+    ["data-job-view", jobsView],
+  ];
+  for (const [attribute, current] of groups) {
+    for (const button of document.querySelectorAll<HTMLElement>(`[${attribute}]`)) {
+      button.setAttribute("aria-pressed", String(button.getAttribute(attribute) === current));
+    }
+  }
+}
+
+/** The three groups differ only in which variable a click sets. */
+function wireJobFilter(id: string, attribute: string, apply: (value: string) => void): void {
+  el(id).addEventListener("click", (event) => {
+    const value = (event.target as HTMLElement)
+      .closest<HTMLElement>(`[${attribute}]`)
+      ?.getAttribute(attribute);
+    if (!value) return;
+    apply(value);
+    syncJobFilterButtons();
+    if (latestState) renderJobs(latestState);
+  });
+}
+
+wireJobFilter("jobs-state", "data-job-state", (value) => {
+  jobStateFilter = value as JobStateFilter;
+});
+wireJobFilter("jobs-source", "data-job-source", (value) => {
+  jobSourceFilter = value as JobSourceFilter;
+});
+wireJobFilter("jobs-view", "data-job-view", (value) => {
+  jobsView = value as JobsView;
+});
+
+syncJobFilterButtons();
 
 nodes.settingsForm.addEventListener("input", () => {
   settingsDirty = true;

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -98,7 +98,9 @@ type State = {
     }[];
   };
   upstreams: UpstreamView[];
-  settings: { comfyDir: string; comfyCommand: string };
+  settings: { comfyDir: string; comfyCommand: string; outputCleanupDays: number };
+  /** ComfyUI's output folder as last scanned; null when there is none. */
+  outputs: { dir: string; files: number; bytes: number; scannedAt: number } | null;
   mode: RunMode;
   accepting: {
     accepting: boolean;
@@ -176,6 +178,12 @@ const nodes = {
   desktopNote: el("desktop-note"),
   notifyEnabled: el<HTMLInputElement>("notify-enabled"),
   notifyNote: el("notify-note"),
+  outputsDir: el("outputs-dir"),
+  outputsInfo: el("outputs-info"),
+  outputsDays: el<HTMLInputElement>("outputs-days"),
+  outputsAuto: el<HTMLInputElement>("outputs-auto"),
+  outputsTrim: el<HTMLButtonElement>("outputs-trim"),
+  outputsNote: el("outputs-note"),
 };
 
 function esc(value: unknown): string {
@@ -209,6 +217,12 @@ function progressPercent(progress: { value: number; max: number }): number {
 /** Bytes as gigabytes with one decimal, the unit VRAM is talked about in. */
 function gb(bytes: number): string {
   return (bytes / 1024 ** 3).toFixed(1);
+}
+
+/** "3.2 GB" or "410 MB", for sizes whose scale is not known in advance. */
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${gb(bytes)} GB`;
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -768,6 +782,59 @@ function syncSettings(state: State): void {
 }
 
 // ---------------------------------------------------------------------------
+// Outputs — ComfyUI's output folder
+// ---------------------------------------------------------------------------
+
+function syncOutputs(state: State): void {
+  if (!state.outputs) {
+    nodes.outputsDir.textContent = "";
+    nodes.outputsInfo.textContent = t("outputs.none");
+    nodes.outputsTrim.disabled = true;
+  } else {
+    nodes.outputsDir.textContent = state.outputs.dir;
+    nodes.outputsInfo.textContent = t("outputs.count", {
+      files: state.outputs.files,
+      size: formatBytes(state.outputs.bytes),
+    });
+    nodes.outputsTrim.disabled = false;
+  }
+
+  // Like the schedule times: only the field being typed into is left alone.
+  if (document.activeElement !== nodes.outputsAuto) {
+    nodes.outputsAuto.value = String(state.settings.outputCleanupDays);
+  }
+}
+
+async function trimOutputsNow(): Promise<void> {
+  const days = Number(nodes.outputsDays.value);
+  if (!Number.isFinite(days) || days < 1) {
+    setNote(nodes.outputsNote, t("outputs.needDays"), true);
+    return;
+  }
+  if (!confirm(t("outputs.confirm", { days }))) return;
+
+  nodes.outputsTrim.disabled = true;
+  setNote(nodes.outputsNote, t("outputs.trimming"));
+  const result = await post<{ removedFiles: number; removedBytes: number }>("/api/outputs/trim", {
+    days,
+  });
+  nodes.outputsTrim.disabled = false;
+
+  if (!result.ok) {
+    setNote(nodes.outputsNote, result.error ?? t("outputs.trimFailed"), true);
+    return;
+  }
+  setNote(
+    nodes.outputsNote,
+    t("outputs.trimmed", {
+      files: result.data?.removedFiles ?? 0,
+      size: formatBytes(result.data?.removedBytes ?? 0),
+    }),
+  );
+  void poll();
+}
+
+// ---------------------------------------------------------------------------
 // Header menus
 // ---------------------------------------------------------------------------
 
@@ -1083,6 +1150,7 @@ function render(state: State): void {
   syncServers(state);
   renderJobs(state);
   syncSettings(state);
+  syncOutputs(state);
   syncMode(state);
   syncAccepting(state);
   syncDesktop(state);
@@ -1459,6 +1527,22 @@ async function toggleComfy(): Promise<void> {
 
 nodes.comfyPower.addEventListener("click", () => void toggleComfy());
 nodes.comfyPower2.addEventListener("click", () => void toggleComfy());
+
+nodes.outputsTrim.addEventListener("click", () => void trimOutputsNow());
+
+// Saved on change like the schedule: one number is not worth a Save button.
+nodes.outputsAuto.addEventListener("change", async () => {
+  const days = Number(nodes.outputsAuto.value);
+  const result = await post("/api/settings", {
+    outputCleanupDays: Number.isFinite(days) ? days : 0,
+  });
+  setNote(
+    nodes.outputsNote,
+    result.ok ? t("outputs.saved") : (result.error ?? t("comfy.saveFailed")),
+    !result.ok,
+  );
+  void poll();
+});
 
 nodes.desktopOpen.addEventListener("click", () => toggle(DESKTOP_POPOVER));
 nodes.modeOpen.addEventListener("click", () => toggle(MODE_POPOVER));

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -69,6 +69,8 @@ type State = {
     comfyStatus: "available" | "busy" | "unavailable";
     queueRunning: number;
     queuePending: number;
+    /** VRAM in bytes, as ComfyUI reports its GPU; null without one. */
+    gpu: { name: string; vramTotal: number; vramFree: number } | null;
     checkedAt: number;
   };
   comfyProcess: {
@@ -196,6 +198,11 @@ function formatTime(ms: number): string {
 /** Whole percent, clamped — a step past the max would otherwise overflow the bar. */
 function progressPercent(progress: { value: number; max: number }): number {
   return Math.min(100, Math.max(0, Math.round((progress.value / progress.max) * 100)));
+}
+
+/** Bytes as gigabytes with one decimal, the unit VRAM is talked about in. */
+function gb(bytes: number): string {
+  return (bytes / 1024 ** 3).toFixed(1);
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -347,11 +354,27 @@ function renderVitals(state: State): void {
     chip(t("vitals.comfy"), esc(comfyStatusLabel(comfy.comfyStatus)), tone),
     chip(t("vitals.running"), pad(comfy.queueRunning)),
     chip(t("vitals.pending"), pad(comfy.queuePending)),
+  ];
+
+  // The GPU is what this machine lends out, so its headroom belongs up here.
+  // The dot only appears when the free VRAM is running out.
+  if (comfy.gpu) {
+    const low = comfy.gpu.vramFree / comfy.gpu.vramTotal < 0.1;
+    chips.push(
+      chip(
+        t("vitals.vram"),
+        `${gb(comfy.gpu.vramTotal - comfy.gpu.vramFree)}/${gb(comfy.gpu.vramTotal)} GB`,
+        low ? "warn" : undefined,
+      ),
+    );
+  }
+
+  chips.push(
     total === 0
       ? chip(t("vitals.agent"), t("vitals.standalone"))
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
     chip(t("vitals.work"), work.label, work.tone),
-  ];
+  );
 
   if (state.progress && state.progress.max > 0) {
     chips.push(chip(t("vitals.progress"), `${progressPercent(state.progress)}%`, "run"));

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -223,6 +223,20 @@ const STRINGS = {
   },
   "jobs.node": { en: "node {node}", ja: "ノード {node}" },
   "jobs.attempt": { en: "attempt {count}", ja: "試行 {count} 回目" },
+  "jobs.all": { en: "All", ja: "すべて" },
+  "jobs.filterState": { en: "State", ja: "状態" },
+  "jobs.filterSource": { en: "Source", ja: "発生元" },
+  "jobs.filterView": { en: "View", ja: "表示" },
+  "jobs.listView": { en: "List", ja: "リスト" },
+  "jobs.galleryView": { en: "Gallery", ja: "ギャラリー" },
+  "jobs.noMatch": {
+    en: "Nothing in the history matches the filter.",
+    ja: "条件に合う履歴はありません。",
+  },
+  "jobs.noMedia": {
+    en: "No images or videos in the filtered runs yet.",
+    ja: "条件に合う画像・動画はまだありません。",
+  },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -144,6 +144,10 @@ const STRINGS = {
     en: "ComfyUI keeps crashing — gave up restarting",
     ja: "ComfyUI がクラッシュを繰り返すため、再起動を諦めました",
   },
+  "notify.outputs-trimmed": {
+    en: "Old outputs deleted: {files} files ({size})",
+    ja: "古い出力を削除しました: {files} ファイル（{size}）",
+  },
 
   "nav.label": { en: "Sections", ja: "セクション" },
   "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
@@ -289,6 +293,32 @@ const STRINGS = {
   },
   "process.startedAt": { en: "started {time} · pid {pid}", ja: "{time} に起動 · pid {pid}" },
   "process.foreign": { en: "not started from here", ja: "ここからは起動していません" },
+
+  // ComfyUI's output folder --------------------------------------------------
+  "outputs.title": { en: "Outputs", ja: "出力ファイル" },
+  "outputs.none": {
+    en: "No output folder under the ComfyUI directory yet.",
+    ja: "ComfyUI ディレクトリの下に output フォルダがまだありません。",
+  },
+  "outputs.count": { en: "{files} files · {size}", ja: "{files} ファイル · {size}" },
+  "outputs.olderThan": { en: "Older than (days)", ja: "何日より古いか" },
+  "outputs.auto": {
+    en: "Auto-delete after (days, 0 = off)",
+    ja: "自動削除する日数（0 = オフ）",
+  },
+  "outputs.trim": { en: "Delete old outputs", ja: "古い出力を削除" },
+  "outputs.confirm": {
+    en: "Delete outputs older than {days} days? The files are removed from disk.",
+    ja: "{days} 日より古い出力を削除しますか？ディスクからファイルが消えます。",
+  },
+  "outputs.needDays": { en: "enter how many days", ja: "日数を入力してください" },
+  "outputs.trimming": { en: "deleting…", ja: "削除中…" },
+  "outputs.trimFailed": { en: "delete failed", ja: "削除できませんでした" },
+  "outputs.trimmed": {
+    en: "removed {files} files ({size})",
+    ja: "{files} ファイル（{size}）を削除しました",
+  },
+  "outputs.saved": { en: "saved", ja: "保存しました" },
 
   // Upstream servers --------------------------------------------------------
   "servers.title": { en: "Upstream servers", ja: "上流サーバー" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -268,6 +268,13 @@ const STRINGS = {
   },
   "workflows.deleteFailed": { en: "delete failed", ja: "削除できませんでした" },
   "workflows.nodes": { en: "{count} nodes", ja: "ノード {count} 個" },
+  "workflows.check": { en: "Check", ja: "チェック" },
+  "workflows.checking": { en: "checking against ComfyUI…", ja: "ComfyUI と照合中…" },
+  "workflows.checkOk": {
+    en: "every node and choice is available on this ComfyUI",
+    ja: "ノードもモデルも、この ComfyUI にすべて揃っています",
+  },
+  "workflows.checkFailed": { en: "check failed", ja: "チェックできませんでした" },
 
   "slot.detected": { en: "detected", ja: "自動検出" },
   "slot.override": { en: "from .slots.json", ja: ".slots.json での指定" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -116,6 +116,35 @@ const STRINGS = {
   "desktop.saved": { en: "saved", ja: "保存しました" },
   "desktop.saveFailed": { en: "save failed", ja: "保存できませんでした" },
 
+  // Notifications — the sentence for each event kind the server records ------
+  "notify.label": { en: "Notifications", ja: "通知" },
+  "notify.enable": { en: "Notify about failures", ja: "失敗や切断を通知する" },
+  "notify.unsupported": {
+    en: "this browser cannot show notifications",
+    ja: "このブラウザは通知に対応していません",
+  },
+  "notify.blocked": {
+    en: "the browser refused — allow notifications for this site",
+    ja: "ブラウザに拒否されました。このサイトの通知を許可してください",
+  },
+  "notify.job-failed": { en: "Job failed: {workflow}", ja: "ジョブ失敗: {workflow}" },
+  "notify.upstream-down": {
+    en: "Job server not answering: {server}",
+    ja: "ジョブサーバー応答なし: {server}",
+  },
+  "notify.upstream-up": {
+    en: "Job server back: {server}",
+    ja: "ジョブサーバー復帰: {server}",
+  },
+  "notify.comfy-crashed": {
+    en: "ComfyUI crashed — restarting it",
+    ja: "ComfyUI がクラッシュしました。再起動します",
+  },
+  "notify.comfy-gave-up": {
+    en: "ComfyUI keeps crashing — gave up restarting",
+    ja: "ComfyUI がクラッシュを繰り返すため、再起動を諦めました",
+  },
+
   "nav.label": { en: "Sections", ja: "セクション" },
   "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
   "nav.comfyui": { en: "ComfyUI", ja: "ComfyUI" },
@@ -332,6 +361,11 @@ const STRINGS = {
 } satisfies Record<string, Entry>;
 
 export type Key = keyof typeof STRINGS;
+
+/** Whether the table has words for `value` — for keys built at runtime. */
+export function isKey(value: string): value is Key {
+  return value in STRINGS;
+}
 
 const DEFAULT_LANG: Lang = LANGS[0].code;
 const STORAGE_KEY = "lang";

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -132,6 +132,7 @@ const STRINGS = {
   "vitals.process": { en: "process", ja: "プロセス" },
   "vitals.access": { en: "access", ja: "アクセス" },
   "vitals.work": { en: "work", ja: "受付" },
+  "vitals.vram": { en: "VRAM", ja: "VRAM" },
   "vitals.progress": { en: "progress", ja: "進捗" },
   "vitals.tokenNeeded": {
     en: "open this page as ?token=<UI_TOKEN>",

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -218,6 +218,7 @@ const STRINGS = {
     ja: "{percent}% · {value}/{max} ステップ",
   },
   "jobs.node": { en: "node {node}", ja: "ノード {node}" },
+  "jobs.attempt": { en: "attempt {count}", ja: "試行 {count} 回目" },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -339,6 +339,87 @@
                   Clear finished
                 </button>
               </div>
+
+              <!-- Narrowing and reshaping only — the history itself is what it
+                   is. The choices live in the page, not on the server. -->
+              <div class="filters">
+                <div
+                  class="segmented text"
+                  id="jobs-state"
+                  role="group"
+                  data-i18n-label="jobs.filterState"
+                >
+                  <button type="button" data-job-state="all" data-i18n="jobs.all">All</button>
+                  <button type="button" data-job-state="running" data-i18n="jobs.running">
+                    running
+                  </button>
+                  <button type="button" data-job-state="succeeded" data-i18n="jobs.succeeded">
+                    succeeded
+                  </button>
+                  <button type="button" data-job-state="failed" data-i18n="jobs.failed">
+                    failed
+                  </button>
+                </div>
+                <div
+                  class="segmented text"
+                  id="jobs-source"
+                  role="group"
+                  data-i18n-label="jobs.filterSource"
+                >
+                  <button type="button" data-job-source="all" data-i18n="jobs.all">All</button>
+                  <button type="button" data-job-source="ui" data-i18n="jobs.ui">UI</button>
+                  <button type="button" data-job-source="upstream" data-i18n="jobs.upstream">
+                    upstream
+                  </button>
+                </div>
+                <div
+                  class="segmented"
+                  id="jobs-view"
+                  role="group"
+                  data-i18n-label="jobs.filterView"
+                >
+                  <button
+                    type="button"
+                    data-job-view="list"
+                    data-i18n-title="jobs.listView"
+                    aria-pressed="true"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <span class="sr-only" data-i18n="jobs.listView">List</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-job-view="gallery"
+                    data-i18n-title="jobs.galleryView"
+                    aria-pressed="false"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      aria-hidden="true"
+                    >
+                      <rect x="4" y="4" width="7" height="7" rx="1" />
+                      <rect x="13" y="4" width="7" height="7" rx="1" />
+                      <rect x="4" y="13" width="7" height="7" rx="1" />
+                      <rect x="13" y="13" width="7" height="7" rx="1" />
+                    </svg>
+                    <span class="sr-only" data-i18n="jobs.galleryView">Gallery</span>
+                  </button>
+                </div>
+              </div>
+
               <div id="jobs"></div>
             </section>
           </div>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -415,6 +415,30 @@
             </div>
             <div id="comfy-process"></div>
           </section>
+
+          <!-- What ComfyUI's output folder holds. Nothing in ComfyUI ever
+               deletes an output, so the disk fills quietly without this. -->
+          <section class="panel">
+            <div class="panel-head"><h2 data-i18n="outputs.title">Outputs</h2></div>
+            <p class="mono muted" id="outputs-dir"></p>
+            <p class="muted" id="outputs-info"></p>
+            <div class="row">
+              <label class="field">
+                <span data-i18n="outputs.olderThan">Older than (days)</span>
+                <input type="number" id="outputs-days" min="1" value="30" />
+              </label>
+              <label class="field">
+                <span data-i18n="outputs.auto">Auto-delete after (days, 0 = off)</span>
+                <input type="number" id="outputs-auto" min="0" />
+              </label>
+            </div>
+            <div class="actions">
+              <button type="button" class="ghost danger" id="outputs-trim" data-i18n="outputs.trim">
+                Delete old outputs
+              </button>
+              <p class="muted" id="outputs-note"></p>
+            </div>
+          </section>
         </section>
 
         <section class="page" data-page="servers" hidden>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -152,6 +152,13 @@
               <button type="button" data-close-action="quit" data-i18n="desktop.quit">Quits</button>
             </div>
 
+            <p class="popover-label" data-i18n="notify.label">Notifications</p>
+            <label class="switch">
+              <input type="checkbox" id="notify-enabled" />
+              <span data-i18n="notify.enable">Notify about failures</span>
+            </label>
+            <p class="muted" id="notify-note"></p>
+
             <p class="muted" data-i18n="desktop.note"></p>
             <p class="muted" id="desktop-note"></p>
           </div>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -13,12 +13,14 @@ import {
   removeJob,
   startJob,
 } from "../jobs";
+import { outputsSnapshot, rescanOutputs, trimOutputs } from "../outputs";
 import { latestProgress } from "../progress";
 import {
   RUN_MODES,
   hostFromUrl,
   loadSettings,
   newUpstreamId,
+  normaliseCleanupDays,
   publicUpstreams,
   saveSettings,
 } from "../settings";
@@ -58,7 +60,12 @@ async function handleState(): Promise<Response> {
     activeWorkflow: await activeWorkflowName(),
     agent: agentSnapshot(),
     upstreams: publicUpstreams(settings),
-    settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
+    settings: {
+      comfyDir: settings.comfyDir,
+      comfyCommand: settings.comfyCommand,
+      outputCleanupDays: settings.outputCleanupDays,
+    },
+    outputs: outputsSnapshot(),
     mode: settings.mode,
     accepting: acceptState(settings),
     progress: latestProgress(),
@@ -265,14 +272,43 @@ async function handleLink(req: Request): Promise<Response> {
 
 async function handleSettingsSave(req: Request): Promise<Response> {
   try {
-    const body = (await req.json()) as { comfyDir?: string; comfyCommand?: string };
+    const body = (await req.json()) as {
+      comfyDir?: string;
+      comfyCommand?: string;
+      outputCleanupDays?: unknown;
+    };
     const saved = await saveSettings({
       ...(body.comfyDir === undefined ? {} : { comfyDir: body.comfyDir.trim() }),
       ...(body.comfyCommand === undefined ? {} : { comfyCommand: body.comfyCommand.trim() }),
+      ...(body.outputCleanupDays === undefined
+        ? {}
+        : { outputCleanupDays: normaliseCleanupDays(body.outputCleanupDays) }),
     });
+    // A different directory means a different output folder to count.
+    if (body.comfyDir !== undefined) void rescanOutputs();
     return Response.json({
-      settings: { comfyDir: saved.comfyDir, comfyCommand: saved.comfyCommand },
+      settings: {
+        comfyDir: saved.comfyDir,
+        comfyCommand: saved.comfyCommand,
+        outputCleanupDays: saved.outputCleanupDays,
+      },
     });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * Delete outputs older than the given days, right now. The stored rule is the
+ * quiet version of this; the button wants its result in the response.
+ */
+async function handleOutputsTrim(req: Request): Promise<Response> {
+  try {
+    const { days } = (await req.json()) as { days?: unknown };
+    if (typeof days !== "number" || !Number.isFinite(days) || days < 1 || days > 3650) {
+      return fail("days must be a number between 1 and 3650");
+    }
+    return Response.json(await trimOutputs(Math.floor(days)));
   } catch (err) {
     return fail(err);
   }
@@ -571,6 +607,7 @@ export function startUi() {
       "/api/link": { POST: guarded(handleLink) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
+      "/api/outputs/trim": { POST: guarded(handleOutputsTrim) },
       "/api/mode": { POST: guarded(handleMode) },
       "/api/accept/pause": { POST: guarded(handlePause) },
       "/api/accept/schedule": { POST: guarded(handleScheduleSave) },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -190,10 +190,10 @@ async function handleUpstreamTest(req: Request): Promise<Response> {
     const secret = (input.secret ?? "").trim() || stored?.secret || "";
     if (!secret) return fail("a secret is needed");
 
-    const { comfyStatus, queueRunning, queuePending } = latestStatus();
+    const { comfyStatus, queueRunning, queuePending, gpu } = latestStatus();
     const result = await testUpstream(
       { name: url, url, hostId, secret },
-      { comfyStatus, queueRunning, queuePending },
+      { comfyStatus, queueRunning, queuePending, gpu },
     );
     return Response.json(result);
   } catch (err) {

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -36,6 +36,7 @@ import {
   setActiveWorkflow,
 } from "../workflow";
 import { claimLinkCode, testUpstream } from "../upstream";
+import { checkWorkflow } from "../validate";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -111,6 +112,17 @@ async function handleWorkflowUpload(req: Request): Promise<Response> {
 
     const summary = await saveWorkflowFile(name, await file.text());
     return Response.json({ workflow: summary });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/** Compare one workflow against the running ComfyUI — see `validate.ts`. */
+async function handleWorkflowCheck(req: Request): Promise<Response> {
+  try {
+    const { name } = (await req.json()) as { name?: string };
+    if (!name) return fail("name is required");
+    return Response.json(await checkWorkflow(name));
   } catch (err) {
     return fail(err);
   }
@@ -600,6 +612,7 @@ export function startUi() {
       "/api/workflows/active": { POST: guarded(handleSetActive) },
       "/api/workflows/reload": { POST: guarded(handleReload) },
       "/api/workflows/upload": { POST: guarded(handleWorkflowUpload) },
+      "/api/workflows/check": { POST: guarded(handleWorkflowCheck) },
       "/api/workflows/delete": { POST: guarded(handleWorkflowDelete) },
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -3,6 +3,7 @@ import { agentSnapshot, applyUpstreamChange } from "../agent";
 import { interrupt, uploadImage, viewUrl } from "../comfy";
 import { comfyProcessState, startComfy, stopComfy } from "../comfy-process";
 import { COMFY_URL, UI_HOSTNAME, UI_PORT, UI_TOKEN, WORKFLOW_DIR } from "../config";
+import { listEvents } from "../events";
 import {
   clearFinishedJobs,
   completeJob,
@@ -63,6 +64,7 @@ async function handleState(): Promise<Response> {
     progress: latestProgress(),
     desktop: settings.desktop,
     jobs: listJobs(),
+    events: listEvents(),
   });
 }
 

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -972,6 +972,36 @@ button.ghost.danger:hover:not(:disabled) {
   background: var(--canvas);
 }
 
+/* Narrowing the run history, and switching how it is drawn. */
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  margin-bottom: var(--space-2xs);
+}
+
+/* Every picture the filtered runs produced, packed edge to edge. */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: var(--space-2xs);
+}
+
+.gallery .cell {
+  display: block;
+}
+
+.gallery img,
+.gallery video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--canvas);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,113 @@
+/**
+ * Check a workflow against the ComfyUI it would run on, without running it.
+ *
+ * A workflow that names a model or a custom node this machine does not have
+ * fails only when a run reaches that node — minutes in, after a claim. ComfyUI
+ * already knows everything needed to say so up front: `/object_info` lists
+ * every installed node class, and for each combo input the exact choices on
+ * offer (which is where checkpoints, LoRAs and VAEs live). This compares the
+ * workflow's literal values against that list.
+ *
+ * Inputs the app rewrites at run time — the detected slots, the input image
+ * above all — are left out: their stored value is about to be replaced, so its
+ * absence proves nothing.
+ */
+
+import { COMFY_URL } from "./config";
+import { loadWorkflow } from "./workflow";
+import type { Slot, WorkflowSlots } from "./slots";
+
+type InputSpec = unknown[];
+
+type ObjectInfo = Record<
+  string,
+  {
+    input?: {
+      required?: Record<string, InputSpec>;
+      optional?: Record<string, InputSpec>;
+    };
+  }
+>;
+
+/**
+ * `/object_info` is megabytes and changes only when models or nodes are
+ * installed, so one minute of reuse spares ComfyUI without going stale enough
+ * to mislead anyone.
+ */
+const OBJECT_INFO_TTL_MS = 60_000;
+
+let cached: { at: number; info: ObjectInfo } | null = null;
+
+async function objectInfo(): Promise<ObjectInfo> {
+  if (cached && Date.now() - cached.at < OBJECT_INFO_TTL_MS) return cached.info;
+
+  let res: Response;
+  try {
+    res = await fetch(`${COMFY_URL}/object_info`, { signal: AbortSignal.timeout(30_000) });
+  } catch {
+    throw new Error("ComfyUI is not answering — start it before checking");
+  }
+  if (!res.ok) throw new Error(`ComfyUI /object_info failed: HTTP ${res.status}`);
+
+  const info = (await res.json()) as ObjectInfo;
+  cached = { at: Date.now(), info };
+  return info;
+}
+
+function slotRefs(slots: WorkflowSlots): Set<string> {
+  const refs = new Set<string>();
+  const add = (slot: Slot | null) => {
+    if (slot) refs.add(`${slot.nodeId}:${slot.input}`);
+  };
+  add(slots.image);
+  add(slots.positive);
+  add(slots.negative);
+  add(slots.length);
+  add(slots.frameRate);
+  for (const seed of slots.seed) add(seed);
+  return refs;
+}
+
+export type WorkflowCheck = {
+  ok: boolean;
+  /** Worded server-side, like every other error the UI passes through. */
+  problems: string[];
+  checkedNodes: number;
+};
+
+export async function checkWorkflow(name: string): Promise<WorkflowCheck> {
+  const loaded = await loadWorkflow(name);
+  const info = await objectInfo();
+  const replaced = slotRefs(loaded.slots);
+
+  const problems: string[] = [];
+
+  for (const [nodeId, node] of Object.entries(loaded.workflow)) {
+    const spec = info[node.class_type];
+    if (!spec) {
+      problems.push(`node ${nodeId}: ${node.class_type} is not installed in this ComfyUI`);
+      continue;
+    }
+
+    const inputSpecs = { ...spec.input?.required, ...spec.input?.optional };
+    for (const [inputName, value] of Object.entries(node.inputs)) {
+      // Combo choices are strings; anything else is a number, a link, or text.
+      if (typeof value !== "string") continue;
+      if (replaced.has(`${nodeId}:${inputName}`)) continue;
+
+      const choices = inputSpecs[inputName]?.[0];
+      if (!Array.isArray(choices) || !choices.every((entry) => typeof entry === "string")) {
+        continue;
+      }
+      if (choices.includes(value)) continue;
+
+      problems.push(
+        choices.length === 0
+          ? `node ${nodeId} (${node.class_type}): ${inputName} "${value}" — this ComfyUI has nothing installed to choose from`
+          : `node ${nodeId} (${node.class_type}): ${inputName} "${value}" is not among the ${choices.length} choices this ComfyUI offers`,
+      );
+    }
+  }
+
+  return { ok: problems.length === 0, problems, checkedNodes: Object.keys(loaded.workflow).length };
+}


### PR DESCRIPTION
#27〜#33 の成果を `dev` に入れ直す PR です。レビュー済み・マージ済みのコードそのままで、新しい実装は含みません。

**何が起きたか。** #13 のときと同じ現象です。スタックの底(#19)を最初にマージしましたが、head ブランチが削除されなかったため GitHub は #27 の base を `dev` に張り替えず、#27 は(すでにマージ済みの)`feat/18-settings-tabs` に入りました。以降も同様に、各 PR は一つ下のフィーチャーブランチにマージされ、`dev` に届いたのはタブ分割だけです。全マージの合流先は `feat/25-runs-filter` になっており(#33 の中身も含むことを `git rev-list` で確認済み)、このブランチをそのまま `dev` に向けています。

**再発防止。** リポジトリ設定の **Automatically delete head branches** を有効にしました。今回と同じ「下から順にマージ」で、次からはマージのたびに base が自動で `dev` へ張り替わります。

入っているもの: watchdog(#27)/ VRAM チップ(#28)/ 通知(#29)/ ジョブ再試行(#30)/ 出力フォルダ管理(#31)/ 履歴フィルタ + ギャラリー(#32)/ ワークフロー検証(#33)。