### PR TITLE
feat(app): auto-update the desktop app from GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ name: Release
 # publish it. Running this by hand from the Actions tab instead builds the same
 # installers and leaves them as workflow artifacts, which is the way to try a
 # build without announcing one.
+#
+# The draft also carries the signed updater artifacts and the `latest.json`
+# installed apps poll (tauri-action writes it because tauri.conf.json turns
+# `createUpdaterArtifacts` on). Publishing the release is what makes
+# `releases/latest/download/latest.json` resolve — which is the moment every
+# installed app starts offering the update.
 on:
   push:
     branches: [main]
@@ -102,6 +108,11 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Signs the updater artifacts. Installed apps refuse an update whose
+          # signature the pubkey in tauri.conf.json cannot verify, so a release
+          # built without these updates nobody.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           # Empty for a manual run: build the installers, create nothing.
           tagName: ${{ needs.version.outputs.bumped == 'true' && format('v{0}', needs.version.outputs.version) || '' }}
@@ -110,6 +121,9 @@ jobs:
           prerelease: false
           releaseBody: |
             Download `ComfyUI-Server_..._x64-setup.exe` and run it.
+
+            Already installed? The app offers this update itself once the
+            release is published — accept the dialog and it restarts updated.
 
             The installer is not code signed, so Windows will show
             "Windows protected your PC" — choose **More info → Run anyway**.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ logs
 .env
 .env.*.local
 
+# Updater signing keys — the private key must never be committed.
+.secrets
+
 # runtime state (active workflow selection, etc.)
 .state.json
 .jobs.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,42 @@ along with `tsc --noEmit`, and compiles the Rust shell with clippy.
 
 ## Releasing
 
-A release is the version in `package.json`. Bump it together with
-`src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` — the release workflow
-stops if the three disagree, since the installer filenames come from Tauri's
-copy — and merge that into `main`.
+### Versions
 
-GitHub Actions then builds the Windows installers and opens a **draft** release
-tagged `v<version>`; publish it when you are ready. Nothing is released by
-pushing a tag by hand any more.
+Versions are `MAJOR.MINOR.PATCH`. While the app is pre-1.0, a release with new
+features bumps MINOR (`0.1.2 → 0.2.0`) and a fix-only release bumps PATCH
+(`0.2.0 → 0.2.1`). **`1.0.0` is reserved for the first release that ships
+premium features** — nothing before that milestone bumps MAJOR, however large.
+
+### Cutting a release
+
+A release is the version in `package.json`. Run
+
+```
+bun run bump 0.2.0
+```
+
+to write the new version into `package.json`, `src-tauri/tauri.conf.json` and
+`src-tauri/Cargo.toml` in one go — the release workflow stops if the three
+disagree, since the installer filenames come from Tauri's copy. Commit that on
+`dev` (`chore(release): 0.2.0`), then merge `dev` into `main`.
+
+GitHub Actions then builds the Windows installers, signs the updater artifacts
+and opens a **draft** release tagged `v<version>`, with the `latest.json` that
+installed apps poll. Publishing the draft is the switch: from that moment every
+installed app offers the update — at launch, daily, and from **Check for
+updates** in the tray — and restarts into the new version. Nothing is released
+by pushing a tag by hand any more.
 
 To try a build without announcing one, run the Release workflow from the Actions
 tab. It builds the same installers and leaves them as workflow artifacts.
+
+### The updater key
+
+Updates are verified against a minisign key pair: the public key sits in
+`tauri.conf.json`, the private key and its password live in the
+`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` Actions
+secrets. **Losing the private key strands every installed app** — they will
+refuse anything signed with a replacement, and only a hand-downloaded installer
+gets them back. Keep a copy of the key and its password somewhere safe outside
+this repository, and never commit them.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ fetches WebView2 if the machine does not already have it.
 You also need a [ComfyUI](https://github.com/comfyanonymous/ComfyUI) install —
 the app runs yours, it does not ship one.
 
+Installing is a one-time job: the app checks this repository's releases when it
+starts and once a day after that, asks before installing anything, and restarts
+into the new version. **Check for updates** in the tray menu does the same on
+the spot. Updates are signed, and the app refuses one whose signature does not
+verify.
+
 Settings, job history and uploaded workflows go to
 `%APPDATA%\desktop-comfyui-server`.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:sidecar": "bun run scripts/build-sidecar.ts",
     "app:dev": "tauri dev",
     "app:build": "tauri build",
+    "bump": "bun run scripts/bump-version.ts",
     "check": "oxlint && oxfmt --write",
     "check:ci": "oxlint && oxfmt --check",
     "check-types": "tsc --noEmit",

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,34 @@
+/**
+ * Write one version everywhere it lives: package.json, tauri.conf.json and
+ * Cargo.toml. The release workflow refuses to build when the three disagree,
+ * so they are only ever changed together, here.
+ *
+ *   bun run bump 0.2.0
+ */
+
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error("usage: bun run bump <major.minor.patch>   e.g. bun run bump 0.2.0");
+  process.exit(1);
+}
+
+/** Targeted replace, not JSON.parse/stringify — the file keeps its own shape. */
+async function bump(path: string, pattern: RegExp, replacement: string): Promise<void> {
+  const file = join(ROOT, path);
+  const text = await Bun.file(file).text();
+  const next = text.replace(pattern, replacement);
+  if (next === text) {
+    console.error(`no version found in ${path}`);
+    process.exit(1);
+  }
+  await Bun.write(file, next);
+  console.log(`${path} → ${version}`);
+}
+
+await bump("package.json", /("version":\s*")[^"]+(")/, `$1${version}$2`);
+await bump("src-tauri/tauri.conf.json", /("version":\s*")[^"]+(")/, `$1${version}$2`);
+await bump("src-tauri/Cargo.toml", /^version = "[^"]+"/m, `version = "${version}"`);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,9 +12,13 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
-# One dialog: the tray asking before it shuts ComfyUI down.
+# Dialogs: the tray asking before it shuts ComfyUI down, and the updater
+# asking before it installs.
 tauri-plugin-dialog = "2"
-# Only ever talks to 127.0.0.1, so no TLS backend is pulled in.
+# Updates from GitHub releases, verified against the pubkey in tauri.conf.json.
+tauri-plugin-updater = "2"
+# Only ever talks to 127.0.0.1, so no TLS backend is asked for here — the
+# updater plugin brings its own for the releases endpoint.
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde_json = "1"
 tokio = { version = "1", features = ["time"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -37,9 +37,14 @@ use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
+use tauri_plugin_updater::UpdaterExt;
 use uuid::Uuid;
 
 const WINDOW: &str = "main";
+
+/// How often a tray app that runs for weeks looks for a new release, on top
+/// of the check at launch.
+const UPDATE_CHECK_EVERY: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// The folder this app owns under the platform's data directory. Deliberately
 /// the project name rather than the bundle identifier, which is what
@@ -154,6 +159,82 @@ fn show_window(app: &AppHandle) {
     }
 }
 
+/// Look for a newer release and offer it. `quiet` is the automatic path:
+/// nothing new means nothing said, and a failed check is a log line — the app
+/// must not greet every launch with an error about being offline. The tray
+/// item passes `false` and gets both answered in dialogs.
+fn check_for_update(app: AppHandle, quiet: bool) {
+    tauri::async_runtime::spawn(async move {
+        let updater = match app.updater() {
+            Ok(updater) => updater,
+            Err(err) => {
+                eprintln!("[update] updater unavailable: {err}");
+                return;
+            }
+        };
+
+        match updater.check().await {
+            Ok(Some(update)) => offer_update(&app, update),
+            Ok(None) => {
+                if !quiet {
+                    app.dialog()
+                        .message("You are on the latest version.")
+                        .title("No update available")
+                        .show(|_| {});
+                }
+            }
+            Err(err) => {
+                eprintln!("[update] check failed: {err}");
+                if !quiet {
+                    app.dialog()
+                        .message(format!("Could not check for updates: {err}"))
+                        .title("Update check failed")
+                        .kind(MessageDialogKind::Error)
+                        .show(|_| {});
+                }
+            }
+        }
+    });
+}
+
+/// Ask before touching anything: installing restarts the app, and the person
+/// may be halfway through a run they care about.
+fn offer_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
+    let handle = app.clone();
+    app.dialog()
+        .message(format!(
+            "Version {} is available (you have {}).\n\nInstall it now? The app restarts when it finishes.",
+            update.version, update.current_version,
+        ))
+        .title("Update available")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Install".to_string(),
+            "Later".to_string(),
+        ))
+        .show(move |confirmed| {
+            if !confirmed {
+                return;
+            }
+            tauri::async_runtime::spawn(async move {
+                // On Windows the installer takes over and this process exits on
+                // its own — the exit handler below kills the sidecar with it.
+                // restart() is for the platforms where it does not.
+                match update.download_and_install(|_, _| {}, || {}).await {
+                    Ok(()) => handle.restart(),
+                    Err(err) => {
+                        eprintln!("[update] install failed: {err}");
+                        handle
+                            .dialog()
+                            .message(format!("Installing the update failed: {err}"))
+                            .title("Update failed")
+                            .kind(MessageDialogKind::Error)
+                            .show(|_| {});
+                    }
+                }
+            });
+        });
+}
+
 /// Take what the server says and make the shell match it. Called on a timer,
 /// so a switch flipped in the page shows up in the tray a moment later.
 fn apply_state(app: &AppHandle, modes: &ModeItems, state: &serde_json::Value) {
@@ -204,6 +285,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,
@@ -297,6 +379,8 @@ fn main() {
                 )?,
             };
             let stop_comfy = MenuItem::with_id(app, "stop-comfy", "Stop ComfyUI", true, None::<&str>)?;
+            let check_updates =
+                MenuItem::with_id(app, "check-updates", "Check for updates", true, None::<&str>)?;
             let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
             let menu = MenuBuilder::new(app)
@@ -306,6 +390,7 @@ fn main() {
                 .separator()
                 .items(&[&stop_comfy])
                 .separator()
+                .items(&[&check_updates])
                 .items(&[&quit])
                 .build()?;
 
@@ -371,6 +456,7 @@ fn main() {
                             api.post("/api/comfy/stop", serde_json::json!({})).await;
                         });
                     }
+                    "check-updates" => check_for_update(app.clone(), false),
                     "quit" => {
                         app.state::<Shell>().quitting.store(true, Ordering::SeqCst);
                         app.exit(0);
@@ -423,6 +509,16 @@ fn main() {
                         apply_state(&sync_handle, &modes, &state);
                     }
                     tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+            });
+
+            // Once now and then daily: a tray app runs for weeks, and an app
+            // that only ever checked at launch would quietly fall behind.
+            let update_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                loop {
+                    check_for_update(update_handle.clone(), true);
+                    tokio::time::sleep(UPDATE_CHECK_EVERY).await;
                 }
             });
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.ico"],
     "externalBin": ["binaries/comfyui-server"],
     "windows": {
@@ -32,6 +33,17 @@
       "wix": {
         "bannerPath": "installer/wix-banner.bmp",
         "dialogImagePath": "installer/wix-dialog.bmp"
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlCRDM1NUQ5MjJCMjg5NEEKUldSS2liSWkyVlhUbTRVbnRkVkhqcUxrSzRZT2VZK1hNWVFBcHNUbUxyNVRkR3pUNmFJb05mNkoK",
+      "endpoints": [
+        "https://github.com/mintani/desktop-comfyui-server/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
       }
     }
   }


### PR DESCRIPTION
Closes #35.

デスクトップアプリが GitHub Releases から自動アップデートできるようになります。Tauri v2 の updater プラグインを使い、確認ダイアログ → ダウンロード → インストール → 再起動まで一通りです。

**アプリ側(Rust)**

- 起動時に 1 回 + 24 時間ごとに `releases/latest/download/latest.json` を確認します。自動チェックは静かです: 新しいものがなければ何も言わず、失敗(オフラインなど)はログ 1 行。起動のたびにエラーダイアログを出さないためです。
- トレイに **Check for updates** を追加。こちらは手動なので「最新です」「確認できませんでした」も両方ダイアログで答えます。
- 見つかったら「Version X が利用できます(現在 Y)。今インストールしますか？」と確認してからインストールします。実行中の生成があるかもしれないので、黙って再起動はしません。
- Windows ではインストーラー(NSIS, passive モード)がアプリを終了させ、既存の Exit ハンドラがサイドカーも道連れにします。

**署名と配信**

- minisign 鍵ペアを生成し、公開鍵を `tauri.conf.json` に、秘密鍵とパスワードを Actions シークレット `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` に設定済みです(このリポジトリに対して `gh secret set` 済み)。アプリは署名が検証できないアップデートを拒否します。
- `createUpdaterArtifacts: true` により、既存の tauri-action が署名付きアーティファクトと `latest.json` をドラフトリリースに自動で載せます。リリースワークフローへの変更はシークレットを渡す env の追加だけです。
- **ドラフトを publish した瞬間**に `latest.json` が解決するようになり、全インストール済みアプリがアップデートを提案し始めます。

**バージョニング**

- `bun run bump 0.2.0` で package.json / tauri.conf.json / Cargo.toml の 3 箇所を一括更新するスクリプトを追加(3 箇所の不一致はリリースワークフローが止める既存ガードと対)。往復テスト済み(9.9.9 → 0.1.2、不正入力は拒否)。
- CONTRIBUTING に方針を明記: pre-1.0 は機能リリースで MINOR、修正のみは PATCH。**1.0.0 はプレミアム機能を出す最初のリリースに予約**。

**⚠️ 秘密鍵のバックアップを**

秘密鍵とパスワードはこのマシンの `desktop-comfyui-server/.secrets/`(gitignore 済み)にあります。**紛失すると配布済みアプリは二度と自動更新できなくなる**(手動再インストールのみ)ので、パスワードマネージャー等に控えを取ってください。

**確認したこと**

- bump スクリプトの往復・不正入力拒否、`tauri.conf.json` の JSON / `release.yml` の YAML 妥当性、`bun run check:ci` と `tsc --noEmit`。
- Rust はこの環境に cargo がないためコンパイルしていません。CI の Desktop Shell ジョブ(Windows + clippy -D warnings)が検証します。