### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-comfyui-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A ComfyUI job runner with a web management UI. Bring your own API-format workflow.",
   "license": "MIT",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop-comfyui-server"
-version = "0.1.2"
+version = "0.2.0"
 description = "Desktop shell for the ComfyUI job runner"
 edition = "2021"
 rust-version = "1.77.2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Desktop ComfyUI Server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "identifier": "dev.mintani.desktop-comfyui-server",
   "build": {
     "beforeDevCommand": "bun run build:sidecar",


### PR DESCRIPTION
Closes #37. #36(自動アップデート)の上に積んだスタック PR です。

`bun run bump 0.2.0` の結果だけのコミットです(package.json / tauri.conf.json / Cargo.toml の 3 箇所)。

マージ順: **#34(取り残しリカバリ)→ #36(自動アップデート)→ この PR** の順で dev に入れてください。head ブランチの自動削除を有効にしたので、下がマージされるたびに base は自動で dev に張り替わります。この PR が dev に入ったら、dev → main のマージがそのまま 0.2.0 のリリースになります。