### PR TITLE
chore(release): ship 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
+# main only receives releases; the work happens on dev and the branches off it.
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 # Cancel an in-flight run when the same branch is pushed again.
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
 
 # main only receives releases; the work happens on dev and the branches off it.
+# Pull requests are deliberately not filtered: a stacked pull request targets
+# the branch below it in the stack, and those names cannot be listed here.
 on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main, dev]
 
 # Cancel an in-flight run when the same branch is pushed again.
 concurrency:

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,67 @@
+name: Close issues
+
+# `Closes #12` in a pull request closes that issue only when the pull request is
+# merged into the default branch — and that is `main`, which receives releases
+# rather than work. Every pull request here lands on `dev`, so this does what
+# GitHub would have done if `dev` were the default.
+#
+# `pull_request_target`, not `pull_request`: a pull request from a fork gets a
+# read-only token, which cannot close anything. Nothing from the pull request is
+# checked out or run here, so running in the base context brings no risk.
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [dev]
+
+jobs:
+  close:
+    name: Close what it answers
+    # Closing a pull request without merging it answers nothing.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Close the issues the pull request names
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          # Through the environment rather than inlined: the body is whatever
+          # somebody typed, and `${{ }}` pasted into a script would run it.
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          issues=$(printf '%s' "$BODY" |
+            grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?) +#[0-9]+' |
+            grep -oE '[0-9]+' | sort -un)
+
+          if [ -z "$issues" ]; then
+            echo "#$NUMBER names no issue to close."
+            exit 0
+          fi
+
+          for issue in $issues; do
+            # The issues API answers for pull requests too, which is how one that
+            # is really a pull request is told apart from an issue.
+            info=$(gh api "repos/$REPO/issues/$issue" 2>/dev/null) || info='{}'
+            state=$(jq -r '.state // "missing"' <<< "$info")
+
+            if [ "$(jq -r 'if .pull_request then "yes" else "no" end' <<< "$info")" = yes ]; then
+              echo "#$issue is a pull request — left alone."
+              continue
+            fi
+            # Already closed by hand, or a number that names nothing: neither is
+            # a reason to fail a merge that has already happened.
+            if [ "$state" != open ]; then
+              echo "#$issue is $state — left alone."
+              continue
+            fi
+
+            gh issue close "$issue" --repo "$REPO" --comment \
+              "Closed by #$NUMBER, merged into \`dev\`. It reaches \`main\` with the next release."
+            echo "Closed #$issue." >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -5,19 +5,25 @@ name: Close issues
 # rather than work. Every pull request here lands on `dev`, so this does what
 # GitHub would have done if `dev` were the default.
 #
-# `pull_request_target`, not `pull_request`: a pull request from a fork gets a
-# read-only token, which cannot close anything. Nothing from the pull request is
-# checked out or run here, so running in the base context brings no risk.
+# `pull_request`, not `pull_request_target`: the target event takes its
+# workflow file from the default branch, and this file lives only on `dev`, so
+# as a target workflow it never fired. The plain event reads the file from the
+# pull request's merge result, which has it as soon as `dev` does. The price is
+# pull requests from forks — their read-only token cannot close anything — and
+# the `if` below skips those rather than failing them.
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
     branches: [dev]
 
 jobs:
   close:
     name: Close what it answers
-    # Closing a pull request without merging it answers nothing.
-    if: github.event.pull_request.merged == true
+    # Closing a pull request without merging it answers nothing, and a fork's
+    # read-only token could not close anything anyway.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,15 @@
 name: Release
 
-# Push a tag to get installers people can download:
-#
-#   git tag v0.1.0 && git push origin v0.1.0
-#
-# The release is created as a draft, so nothing becomes public until you say so.
-# Running this by hand from the Actions tab instead builds the same installers
-# and leaves them as workflow artifacts, which is the way to try a build without
-# announcing one.
+# Releases follow the version in package.json. Land a commit on main whose
+# version differs from the commit before it and this builds the installers and
+# opens a draft release for that version, so nothing becomes public until you
+# publish it. Running this by hand from the Actions tab instead builds the same
+# installers and leaves them as workflow artifacts, which is the way to try a
+# build without announcing one.
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
+    paths: [package.json]
   workflow_dispatch:
 
 concurrency:
@@ -18,8 +17,56 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      bumped: ${{ steps.check.outputs.bumped }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          # One commit back, to compare package.json against.
+          fetch-depth: 2
+
+      # package.json declares the release, but the installer filenames come from
+      # tauri.conf.json and the crate from Cargo.toml. Left unchecked, a bump in
+      # one of them ships v0.2.0 with 0.1.2 written on the installer.
+      - name: Read the version
+        id: check
+        shell: bash
+        run: |
+          version=$(jq -r .version package.json)
+          app=$(jq -r .version src-tauri/tauri.conf.json)
+          crate=$(grep -m1 '^version = ' src-tauri/Cargo.toml | cut -d'"' -f2)
+          if [ "$version" != "$app" ] || [ "$version" != "$crate" ]; then
+            echo "::error::versions differ: package.json $version, tauri.conf.json $app, Cargo.toml $crate"
+            exit 1
+          fi
+
+          previous=""
+          if git rev-parse -q --verify HEAD^ >/dev/null; then
+            previous=$(git show HEAD^:package.json | jq -r .version)
+          fi
+
+          bumped=false
+          if [ "${{ github.event_name }}" = push ] && [ "$version" != "$previous" ]; then
+            bumped=true
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "bumped=$bumped" >> "$GITHUB_OUTPUT"
+          echo "Version $version, was ${previous:-none}. Release: $bumped." >> "$GITHUB_STEP_SUMMARY"
+
   windows:
     name: Windows installer
+    needs: version
+    # A push that touches package.json without changing the version — a script,
+    # a dependency — is not a release.
+    if: needs.version.outputs.bumped == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     timeout-minutes: 60
 
@@ -56,7 +103,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+          # Empty for a manual run: build the installers, create nothing.
+          tagName: ${{ needs.version.outputs.bumped == 'true' && format('v{0}', needs.version.outputs.version) || '' }}
           releaseName: Desktop ComfyUI Server __VERSION__
           releaseDraft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ name: Release
 # publish it. Running this by hand from the Actions tab instead builds the same
 # installers and leaves them as workflow artifacts, which is the way to try a
 # build without announcing one.
+#
+# The draft also carries the signed updater artifacts and the `latest.json`
+# installed apps poll (tauri-action writes it because tauri.conf.json turns
+# `createUpdaterArtifacts` on). Publishing the release is what makes
+# `releases/latest/download/latest.json` resolve — which is the moment every
+# installed app starts offering the update.
 on:
   push:
     branches: [main]
@@ -102,6 +108,11 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Signs the updater artifacts. Installed apps refuse an update whose
+          # signature the pubkey in tauri.conf.json cannot verify, so a release
+          # built without these updates nobody.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           # Empty for a manual run: build the installers, create nothing.
           tagName: ${{ needs.version.outputs.bumped == 'true' && format('v{0}', needs.version.outputs.version) || '' }}
@@ -110,6 +121,9 @@ jobs:
           prerelease: false
           releaseBody: |
             Download `ComfyUI-Server_..._x64-setup.exe` and run it.
+
+            Already installed? The app offers this update itself once the
+            release is published — accept the dialog and it restarts updated.
 
             The installer is not code signed, so Windows will show
             "Windows protected your PC" — choose **More info → Run anyway**.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ logs
 .env
 .env.*.local
 
+# Updater signing keys — the private key must never be committed.
+.secrets
+
 # runtime state (active workflow selection, etc.)
 .state.json
 .jobs.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Work starts from an issue. Issue, commit and pull request titles are written in
+English.
+
+## Branches
+
+`main` holds what has been released. Everything else happens on `dev`.
+
+1. Open an issue describing the change.
+2. Branch off `dev`, named `<type>/<issue>-<short-name>` — `feat/12-tray-menu`,
+   `fix/13-stop-dialog`, `chore/14-release-flow`, `docs/15-readme`.
+3. Open a pull request into `dev` and name the issue in it — `Closes #12`.
+4. When `dev` is ready to ship, merge it into `main`. That is a release.
+
+## Commits
+
+[Conventional Commits](https://www.conventionalcommits.org), with a scope where
+one helps: `feat(tray): keep running after the window closes`. One line, and
+within 72 characters — GitHub cuts off longer subjects.
+
+`lefthook` runs oxlint and oxfmt over staged files on commit. CI repeats them
+along with `tsc --noEmit`, and compiles the Rust shell with clippy.
+
+## Releasing
+
+A release is the version in `package.json`. Bump it together with
+`src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` — the release workflow
+stops if the three disagree, since the installer filenames come from Tauri's
+copy — and merge that into `main`.
+
+GitHub Actions then builds the Windows installers and opens a **draft** release
+tagged `v<version>`; publish it when you are ready. Nothing is released by
+pushing a tag by hand any more.
+
+To try a build without announcing one, run the Release workflow from the Actions
+tab. It builds the same installers and leaves them as workflow artifacts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,19 @@ English.
 3. Open a pull request into `dev` and name the issue in it — `Closes #12`.
 4. When `dev` is ready to ship, merge it into `main`. That is a release.
 
-## Commits
+## Titles
 
+Issues, commits and pull requests are all titled with
 [Conventional Commits](https://www.conventionalcommits.org), with a scope where
 one helps: `feat(tray): keep running after the window closes`. One line, and
 within 72 characters — GitHub cuts off longer subjects.
+
+An issue is titled for the change it asks for, a commit for the change it makes,
+and a pull request for what its branch does as a whole. Those three often read
+the same, which is the point: an issue and the work that answers it are easy to
+line up. Reasoning goes in the body, never in the title.
+
+## Checks
 
 `lefthook` runs oxlint and oxfmt over staged files on commit. CI repeats them
 along with `tsc --noEmit`, and compiles the Rust shell with clippy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ and a pull request for what its branch does as a whole. Those three often read
 the same, which is the point: an issue and the work that answers it are easy to
 line up. Reasoning goes in the body, never in the title.
 
+Titles are English. A body can be in whichever language the discussion is in —
+Japanese is common here — since it is read by whoever is looking at that issue
+rather than by everyone scanning a list.
+
 ## Checks
 
 `lefthook` runs oxlint and oxfmt over staged files on commit. CI repeats them

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,42 @@ along with `tsc --noEmit`, and compiles the Rust shell with clippy.
 
 ## Releasing
 
-A release is the version in `package.json`. Bump it together with
-`src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` — the release workflow
-stops if the three disagree, since the installer filenames come from Tauri's
-copy — and merge that into `main`.
+### Versions
 
-GitHub Actions then builds the Windows installers and opens a **draft** release
-tagged `v<version>`; publish it when you are ready. Nothing is released by
-pushing a tag by hand any more.
+Versions are `MAJOR.MINOR.PATCH`. While the app is pre-1.0, a release with new
+features bumps MINOR (`0.1.2 → 0.2.0`) and a fix-only release bumps PATCH
+(`0.2.0 → 0.2.1`). **`1.0.0` is reserved for the first release that ships
+premium features** — nothing before that milestone bumps MAJOR, however large.
+
+### Cutting a release
+
+A release is the version in `package.json`. Run
+
+```
+bun run bump 0.2.0
+```
+
+to write the new version into `package.json`, `src-tauri/tauri.conf.json` and
+`src-tauri/Cargo.toml` in one go — the release workflow stops if the three
+disagree, since the installer filenames come from Tauri's copy. Commit that on
+`dev` (`chore(release): 0.2.0`), then merge `dev` into `main`.
+
+GitHub Actions then builds the Windows installers, signs the updater artifacts
+and opens a **draft** release tagged `v<version>`, with the `latest.json` that
+installed apps poll. Publishing the draft is the switch: from that moment every
+installed app offers the update — at launch, daily, and from **Check for
+updates** in the tray — and restarts into the new version. Nothing is released
+by pushing a tag by hand any more.
 
 To try a build without announcing one, run the Release workflow from the Actions
 tab. It builds the same installers and leaves them as workflow artifacts.
+
+### The updater key
+
+Updates are verified against a minisign key pair: the public key sits in
+`tauri.conf.json`, the private key and its password live in the
+`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` Actions
+secrets. **Losing the private key strands every installed app** — they will
+refuse anything signed with a replacement, and only a hand-downloaded installer
+gets them back. Keep a copy of the key and its password somewhere safe outside
+this repository, and never commit them.

--- a/README.md
+++ b/README.md
@@ -61,18 +61,23 @@ If you would rather not trust a binary at all, it runs from source — see
 
 ## The window
 
-Two pages, because most of the time the app is left alone and only visited to
-change something.
+One tab per subject, so the thing you came to change is a click away rather
+than somewhere down a long page.
 
-**Settings** is where it opens.
+**Workflows** is where it opens: add a workflow, see what each one exposes,
+choose the one used for jobs that do not name one, delete the ones you are
+done with.
 
-- *Upload* / *Installed* — add a workflow, see what each one exposes, choose the
-  one used for jobs that do not name one, delete the ones you are done with
-- *ComfyUI* — where it is installed, and optionally the command to run there
-- *Process* — start and stop ComfyUI, with the tail of its output so a wrong
-  command explains itself
-- *Upstream servers* — link one with a code from its own UI, or fill a row in
-  by hand; reorder and disable them here too. The order is the priority
+**ComfyUI** points the app at your install — where it is, and optionally the
+command to run there — and starts and stops it, with the tail of its output so
+a wrong command explains itself.
+
+**Servers** attaches job servers: link one with a code from its own UI, or fill
+a row in by hand; reorder and disable them here too. The order is the priority.
+
+**Accepting** says when job servers get work out of this machine — a hold for
+the next while, or a daily window. [When it accepts](#when-it-accepts) has the
+details.
 
 **Generate** runs a workflow by hand: a form on one side, the run history on the
 other. Handy for checking a workflow does what you think before a job server
@@ -81,7 +86,7 @@ starts sending work.
 A run in flight carries a bar — the steps ComfyUI has done out of the steps it
 expects, and the node it is on — so a slow workflow can be told from a stuck one.
 Jobs claimed from a job server land in the same history, so they get the same
-bar, and the status bar carries the percentage on either page.
+bar, and the status bar carries the percentage on every page.
 
 The header switches the theme and the language, and the button beside them opens
 the app's own settings — the same switches the tray menu carries.
@@ -113,8 +118,7 @@ The same three are in the tray, so it can be changed with the window closed.
 
 ### When it accepts
 
-*Accepting* does not have to mean right now. Under *Accepting jobs* on the
-Settings page:
+*Accepting* does not have to mean right now. On the Accepting page:
 
 - **Hold off for** 15, 30 or 60 minutes. The machine stops taking jobs and
   starts again on its own, which is what you want when the GPU is yours for the
@@ -151,7 +155,7 @@ Both are stored with everything else, so the tray and the page always agree.
 
 ## Pointing it at ComfyUI
 
-On the Settings page, put the folder in *Directory*:
+On the ComfyUI page, put the folder in *Directory*:
 
 | What you installed | What to enter | What gets run |
 | ------------------ | ------------- | ------------- |
@@ -169,7 +173,7 @@ launched can be stopped from the app.
 ## Bring your own workflow
 
 In ComfyUI, turn on **Settings → Lite Graph → Enable Dev mode options**, then
-use **Workflow → Export (API)**. Upload the JSON on the Settings page.
+use **Workflow → Export (API)**. Upload the JSON on the Workflows page.
 
 ComfyUI's API format is a flat map of node id to node, and each node records its
 class and how its inputs are wired. That is enough to find the interesting
@@ -184,7 +188,7 @@ inputs without being told:
 | `length`    | a node with a numeric `length` input (frame count on video workflows) |
 | `frameRate` | a node with a numeric `frame_rate` input                              |
 
-The Settings page shows which of these were found, so a workflow that needs help
+The Workflows page shows which of these were found, so a workflow that needs help
 is obvious before you run it. Anything not found is simply not offered — a
 workflow with no `LoadImage` gets no image field.
 
@@ -210,7 +214,7 @@ reported in the UI rather than silently ignored.
 
 ## Attaching a job server
 
-Left alone, the app runs standalone. Add a server on the Settings page and it
+Left alone, the app runs standalone. Add a server on the Servers page and it
 also polls for queued jobs, runs them through the active workflow and uploads
 the result — which is the point of the tray: the machine keeps serving with
 nothing on screen.
@@ -245,7 +249,7 @@ A server may also implement one endpoint outside that block:
 | ------------------------------- | --------------------------------------------------------- |
 | `POST /api/internal/hosts/link` | trade `{ code }` for `{ hostId, hostSecret, hostName }`    |
 
-That is what *Link* on the Settings page calls. It is unauthenticated because
+That is what *Link* on the Servers page calls. It is unauthenticated because
 the code is the credential: the server issues it, it works once, and it expires.
 A server without it is used the same way as before — fill the host id and secret
 in by hand.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,26 @@ answering claims nothing from a job server either, whatever its state says.
 
 The same three are in the tray, so it can be changed with the window closed.
 
+### When it accepts
+
+*Accepting* does not have to mean right now. Under *Accepting jobs* on the
+Settings page:
+
+- **Hold off for** 15, 30 or 60 minutes. The machine stops taking jobs and
+  starts again on its own, which is what you want when the GPU is yours for the
+  next half hour and remembering to switch back is the hard part.
+- **Every day, only between two times.** 02:00 to 08:00 lends the GPU out
+  overnight. An end before the start crosses midnight, so that window is tonight
+  until tomorrow morning rather than an error.
+
+Both only hold jobs back. ComfyUI stays up, runs you start here still go, and
+job servers still see the machine — they simply get nothing out of it until the
+hold is over. The header says which of the two is holding it and the status bar
+says how much is left.
+
+A hold is stored with its end time rather than counted down in memory, so
+restarting the app in the middle of one does not start claiming early.
+
 ## The tray
 
 Closing the window does not stop anything. The app stays in the tray with:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ details.
 
 **Generate** runs a workflow by hand: a form on one side, the run history on the
 other. Handy for checking a workflow does what you think before a job server
-starts sending work.
+starts sending work. The history narrows by state and by where the job came
+from, and flips into a gallery of everything the filtered runs produced.
 
 A run in flight carries a bar — the steps ComfyUI has done out of the steps it
 expects, and the node it is on — so a slow workflow can be told from a stuck one.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ done with.
 
 **ComfyUI** points the app at your install — where it is, and optionally the
 command to run there — and starts and stops it, with the tail of its output so
-a wrong command explains itself.
+a wrong command explains itself. A ComfyUI started here that crashes is started
+again on its own; three crashes in a row right after starting read as a broken
+command, so it stops trying and says why in the log.
 
 **Servers** attaches job servers: link one with a code from its own UI, or fill
 a row in by hand; reorder and disable them here too. The order is the priority.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ change something.
 - *ComfyUI* — where it is installed, and optionally the command to run there
 - *Process* — start and stop ComfyUI, with the tail of its output so a wrong
   command explains itself
-- *Upstream servers* — add, reorder and disable job servers. The order is the
-  priority
+- *Upstream servers* — link one with a code from its own UI, or fill a row in
+  by hand; reorder and disable them here too. The order is the priority
 
 **Generate** runs a workflow by hand: a form on one side, the run history on the
 other. Handy for checking a workflow does what you think before a job server
@@ -238,6 +238,17 @@ authenticated with `Authorization: Bearer <secret>`:
 | `POST /jobs/:id/result`    | the produced file, as the raw request body                   |
 | `POST /jobs/:id/complete`  | mark done                                                    |
 | `POST /jobs/:id/fail`      | mark failed, with `{ reason }`                               |
+
+A server may also implement one endpoint outside that block:
+
+| Endpoint                        | Purpose                                                   |
+| ------------------------------- | --------------------------------------------------------- |
+| `POST /api/internal/hosts/link` | trade `{ code }` for `{ hostId, hostSecret, hostName }`    |
+
+That is what *Link* on the Settings page calls. It is unauthenticated because
+the code is the credential: the server issues it, it works once, and it expires.
+A server without it is used the same way as before — fill the host id and secret
+in by hand.
 
 A claimed job looks like:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ is inside. What you can check instead:
 - Everything the app runs is in this repository. There is no separate download
   and no telemetry — it only talks to your ComfyUI and to job servers you add
   yourself.
-- The installers are built by GitHub Actions from the tagged commit, not
+- The installers are built by GitHub Actions from the released commit, not
   uploaded from anyone's machine. The build log for each release is public.
 - It contains exactly two programs: `desktop-comfyui-server.exe`, the window,
   and `comfyui-server.exe`, the server from `src/`. The size is the Bun runtime
@@ -312,12 +312,10 @@ The server is bundled by `bun build --compile`, which carries the Bun runtime,
 so the sidecar is about 100 MB before compression.
 
 Installers are built by
-[`.github/workflows/release.yml`](.github/workflows/release.yml). Push a tag and
-they appear on a draft release:
-
-```bash
-git tag v0.1.0 && git push origin v0.1.0
-```
+[`.github/workflows/release.yml`](.github/workflows/release.yml). A release is
+the version in `package.json`: bump it — along with `src-tauri/tauri.conf.json`
+and `src-tauri/Cargo.toml`, which have to agree — and when that lands on `main`
+the installers appear on a draft release tagged `v<version>`.
 
 To try a build without announcing one, run the workflow by hand from the Actions
 tab; the installers come back as workflow artifacts instead.
@@ -329,6 +327,10 @@ bun run dev           # reload on change
 bun run check         # oxlint + oxfmt
 bun run check-types   # tsc --noEmit
 ```
+
+Work starts from an issue and lands on `dev`; `main` holds what has been
+released. [`CONTRIBUTING.md`](CONTRIBUTING.md) has the branch, commit and
+release steps.
 
 `src/` is the server and the UI, `src-tauri/` is the desktop shell. The two talk
 over HTTP like any other client, so the shell holds no state of its own — it

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ fetches WebView2 if the machine does not already have it.
 You also need a [ComfyUI](https://github.com/comfyanonymous/ComfyUI) install —
 the app runs yours, it does not ship one.
 
+Installing is a one-time job: the app checks this repository's releases when it
+starts and once a day after that, asks before installing anything, and restarts
+into the new version. **Check for updates** in the tray menu does the same on
+the spot. Updates are signed, and the app refuses one whose signature does not
+verify.
+
 Settings, job history and uploaded workflows go to
 `%APPDATA%\desktop-comfyui-server`.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ done with.
 command to run there — and starts and stops it, with the tail of its output so
 a wrong command explains itself. A ComfyUI started here that crashes is started
 again on its own; three crashes in a row right after starting read as a broken
-command, so it stops trying and says why in the log.
+command, so it stops trying and says why in the log. An *Outputs* panel shows
+how much disk ComfyUI's output folder holds, with a button — and an optional
+standing rule — that deletes files older than a chosen number of days.
 
 **Servers** attaches job servers: link one with a code from its own UI, or fill
 a row in by hand; reorder and disable them here too. The order is the priority.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ The Workflows page shows which of these were found, so a workflow that needs hel
 is obvious before you run it. Anything not found is simply not offered — a
 workflow with no `LoadImage` gets no image field.
 
+*Check* on a workflow's row goes further: it asks the running ComfyUI — via
+`/object_info` — whether every node type in the file exists there, and whether
+every file-choosing input (checkpoints, LoRAs, VAEs, …) names something
+actually installed, without running anything. Inputs the app replaces at run
+time, the input image above all, are left out of the check.
+
 Outputs are not detected in advance. Whatever ComfyUI records in its history for
 the run is collected, so images, videos and gifs all work with no configuration.
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ also polls for queued jobs, runs them through the active workflow and uploads
 the result — which is the point of the tray: the machine keeps serving with
 nothing on screen.
 
+Each row has a *Test* button. It sends one heartbeat there and then, so a wrong
+secret answers `HTTP 401` immediately instead of looking like an unreachable host
+until the next beat. It tests what is on screen, so a secret you have typed but
+not saved is the one tried; leaving the box blank tests the stored one.
+
 Several can be served at once. They are asked in the order the list puts them,
 so the top of the list is the priority: a server with work queued keeps this
 machine until it runs dry, and only then does the next one get a turn.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ change something.
 other. Handy for checking a workflow does what you think before a job server
 starts sending work.
 
+A run in flight carries a bar — the steps ComfyUI has done out of the steps it
+expects, and the node it is on — so a slow workflow can be told from a stuck one.
+Jobs claimed from a job server land in the same history, so they get the same
+bar, and the status bar carries the percentage on either page.
+
 The header switches the theme and the language, and the button beside them opens
 the app's own settings — the same switches the tray menu carries.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-comfyui-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A ComfyUI job runner with a web management UI. Bring your own API-format workflow.",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:sidecar": "bun run scripts/build-sidecar.ts",
     "app:dev": "tauri dev",
     "app:build": "tauri build",
+    "bump": "bun run scripts/bump-version.ts",
     "check": "oxlint && oxfmt --write",
     "check:ci": "oxlint && oxfmt --check",
     "check-types": "tsc --noEmit",

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,34 @@
+/**
+ * Write one version everywhere it lives: package.json, tauri.conf.json and
+ * Cargo.toml. The release workflow refuses to build when the three disagree,
+ * so they are only ever changed together, here.
+ *
+ *   bun run bump 0.2.0
+ */
+
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error("usage: bun run bump <major.minor.patch>   e.g. bun run bump 0.2.0");
+  process.exit(1);
+}
+
+/** Targeted replace, not JSON.parse/stringify — the file keeps its own shape. */
+async function bump(path: string, pattern: RegExp, replacement: string): Promise<void> {
+  const file = join(ROOT, path);
+  const text = await Bun.file(file).text();
+  const next = text.replace(pattern, replacement);
+  if (next === text) {
+    console.error(`no version found in ${path}`);
+    process.exit(1);
+  }
+  await Bun.write(file, next);
+  console.log(`${path} → ${version}`);
+}
+
+await bump("package.json", /("version":\s*")[^"]+(")/, `$1${version}$2`);
+await bump("src-tauri/tauri.conf.json", /("version":\s*")[^"]+(")/, `$1${version}$2`);
+await bump("src-tauri/Cargo.toml", /^version = "[^"]+"/m, `version = "${version}"`);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,9 +12,13 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
-# One dialog: the tray asking before it shuts ComfyUI down.
+# Dialogs: the tray asking before it shuts ComfyUI down, and the updater
+# asking before it installs.
 tauri-plugin-dialog = "2"
-# Only ever talks to 127.0.0.1, so no TLS backend is pulled in.
+# Updates from GitHub releases, verified against the pubkey in tauri.conf.json.
+tauri-plugin-updater = "2"
+# Only ever talks to 127.0.0.1, so no TLS backend is asked for here — the
+# updater plugin brings its own for the releases endpoint.
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde_json = "1"
 tokio = { version = "1", features = ["time"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop-comfyui-server"
-version = "0.1.2"
+version = "0.2.0"
 description = "Desktop shell for the ComfyUI job runner"
 edition = "2021"
 rust-version = "1.77.2"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -37,9 +37,14 @@ use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
+use tauri_plugin_updater::UpdaterExt;
 use uuid::Uuid;
 
 const WINDOW: &str = "main";
+
+/// How often a tray app that runs for weeks looks for a new release, on top
+/// of the check at launch.
+const UPDATE_CHECK_EVERY: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// The folder this app owns under the platform's data directory. Deliberately
 /// the project name rather than the bundle identifier, which is what
@@ -154,6 +159,82 @@ fn show_window(app: &AppHandle) {
     }
 }
 
+/// Look for a newer release and offer it. `quiet` is the automatic path:
+/// nothing new means nothing said, and a failed check is a log line — the app
+/// must not greet every launch with an error about being offline. The tray
+/// item passes `false` and gets both answered in dialogs.
+fn check_for_update(app: AppHandle, quiet: bool) {
+    tauri::async_runtime::spawn(async move {
+        let updater = match app.updater() {
+            Ok(updater) => updater,
+            Err(err) => {
+                eprintln!("[update] updater unavailable: {err}");
+                return;
+            }
+        };
+
+        match updater.check().await {
+            Ok(Some(update)) => offer_update(&app, update),
+            Ok(None) => {
+                if !quiet {
+                    app.dialog()
+                        .message("You are on the latest version.")
+                        .title("No update available")
+                        .show(|_| {});
+                }
+            }
+            Err(err) => {
+                eprintln!("[update] check failed: {err}");
+                if !quiet {
+                    app.dialog()
+                        .message(format!("Could not check for updates: {err}"))
+                        .title("Update check failed")
+                        .kind(MessageDialogKind::Error)
+                        .show(|_| {});
+                }
+            }
+        }
+    });
+}
+
+/// Ask before touching anything: installing restarts the app, and the person
+/// may be halfway through a run they care about.
+fn offer_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
+    let handle = app.clone();
+    app.dialog()
+        .message(format!(
+            "Version {} is available (you have {}).\n\nInstall it now? The app restarts when it finishes.",
+            update.version, update.current_version,
+        ))
+        .title("Update available")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Install".to_string(),
+            "Later".to_string(),
+        ))
+        .show(move |confirmed| {
+            if !confirmed {
+                return;
+            }
+            tauri::async_runtime::spawn(async move {
+                // On Windows the installer takes over and this process exits on
+                // its own — the exit handler below kills the sidecar with it.
+                // restart() is for the platforms where it does not.
+                match update.download_and_install(|_, _| {}, || {}).await {
+                    Ok(()) => handle.restart(),
+                    Err(err) => {
+                        eprintln!("[update] install failed: {err}");
+                        handle
+                            .dialog()
+                            .message(format!("Installing the update failed: {err}"))
+                            .title("Update failed")
+                            .kind(MessageDialogKind::Error)
+                            .show(|_| {});
+                    }
+                }
+            });
+        });
+}
+
 /// Take what the server says and make the shell match it. Called on a timer,
 /// so a switch flipped in the page shows up in the tray a moment later.
 fn apply_state(app: &AppHandle, modes: &ModeItems, state: &serde_json::Value) {
@@ -204,6 +285,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,
@@ -297,6 +379,8 @@ fn main() {
                 )?,
             };
             let stop_comfy = MenuItem::with_id(app, "stop-comfy", "Stop ComfyUI", true, None::<&str>)?;
+            let check_updates =
+                MenuItem::with_id(app, "check-updates", "Check for updates", true, None::<&str>)?;
             let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
             let menu = MenuBuilder::new(app)
@@ -306,6 +390,7 @@ fn main() {
                 .separator()
                 .items(&[&stop_comfy])
                 .separator()
+                .items(&[&check_updates])
                 .items(&[&quit])
                 .build()?;
 
@@ -371,6 +456,7 @@ fn main() {
                             api.post("/api/comfy/stop", serde_json::json!({})).await;
                         });
                     }
+                    "check-updates" => check_for_update(app.clone(), false),
                     "quit" => {
                         app.state::<Shell>().quitting.store(true, Ordering::SeqCst);
                         app.exit(0);
@@ -423,6 +509,16 @@ fn main() {
                         apply_state(&sync_handle, &modes, &state);
                     }
                     tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+            });
+
+            // Once now and then daily: a tray app runs for weeks, and an app
+            // that only ever checked at launch would quietly fall behind.
+            let update_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                loop {
+                    check_for_update(update_handle.clone(), true);
+                    tokio::time::sleep(UPDATE_CHECK_EVERY).await;
                 }
             });
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Desktop ComfyUI Server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "identifier": "dev.mintani.desktop-comfyui-server",
   "build": {
     "beforeDevCommand": "bun run build:sidecar",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.ico"],
     "externalBin": ["binaries/comfyui-server"],
     "windows": {
@@ -32,6 +33,17 @@
       "wix": {
         "bannerPath": "installer/wix-banner.bmp",
         "dialogImagePath": "installer/wix-dialog.bmp"
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlCRDM1NUQ5MjJCMjg5NEEKUldSS2liSWkyVlhUbTRVbnRkVkhqcUxrSzRZT2VZK1hNWVFBcHNUbUxyNVRkR3pUNmFJb05mNkoK",
+      "endpoints": [
+        "https://github.com/mintani/desktop-comfyui-server/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
       }
     }
   }

--- a/src/accepting.ts
+++ b/src/accepting.ts
@@ -1,0 +1,98 @@
+/**
+ * When this machine takes work from a job server.
+ *
+ * The run mode is a decision someone made, so nothing here changes it. A
+ * schedule or a pause is a gate in front of claiming instead: the mode still
+ * says "accepting", and this says whether right now counts. Keeping the two
+ * apart is what lets the tray go on showing what was chosen while the machine
+ * quietly stops and starts claiming on its own.
+ *
+ * Local runs and ComfyUI itself are untouched by any of it. The point is to
+ * lend the GPU out on a timetable, not to stop being able to use it.
+ */
+
+import type { AcceptSchedule, Settings } from "./settings";
+
+/** The furthest ahead a pause may be set, so a slip cannot lend nothing for a week. */
+export const MAX_PAUSE_MINUTES = 24 * 60;
+
+const MINUTE_MS = 60_000;
+
+/** Why nothing is being claimed, or `null` when it is. */
+export type AcceptBlock =
+  /** The mode is not `accepting`. */
+  | "mode"
+  /** Paused for a while, and the while is not up. */
+  | "paused"
+  /** Outside the daily window. */
+  | "schedule";
+
+export type AcceptState = {
+  accepting: boolean;
+  blockedBy: AcceptBlock | null;
+  /** When the pause runs out, or `null` when not paused. */
+  pausedUntil: number | null;
+  schedule: AcceptSchedule;
+};
+
+/** True for a `HH:MM` a day actually contains. */
+export function isTimeOfDay(value: unknown): value is string {
+  return typeof value === "string" && minutesOfDay(value) !== null;
+}
+
+/** `HH:MM` as minutes since midnight, or `null` when it is not one. */
+function minutesOfDay(time: string): number | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}
+
+/**
+ * Whether `now` falls inside the daily window, in this machine's own time zone
+ * — the window is written by whoever sits at it.
+ *
+ * A window whose end is before its start crosses midnight, which is the usual
+ * shape of "while I am asleep", so it is read that way rather than refused. Two
+ * equal ends would describe an empty day; the only useful reading is all of it.
+ */
+export function withinSchedule(schedule: AcceptSchedule, now: Date): boolean {
+  if (!schedule.enabled) return true;
+
+  const from = minutesOfDay(schedule.from);
+  const to = minutesOfDay(schedule.to);
+  // A window that cannot be read is not a reason to stop working.
+  if (from === null || to === null || from === to) return true;
+
+  const current = now.getHours() * 60 + now.getMinutes();
+  return from < to ? current >= from && current < to : current >= from || current < to;
+}
+
+/** What the agent, the API and the header all read to decide the same thing. */
+export function acceptState(settings: Settings, now = Date.now()): AcceptState {
+  const pausedUntil =
+    settings.pauseUntil !== null && settings.pauseUntil > now ? settings.pauseUntil : null;
+
+  const blockedBy: AcceptBlock | null =
+    settings.mode !== "accepting"
+      ? "mode"
+      : pausedUntil !== null
+        ? "paused"
+        : withinSchedule(settings.schedule, new Date(now))
+          ? null
+          : "schedule";
+
+  return { accepting: blockedBy === null, blockedBy, pausedUntil, schedule: settings.schedule };
+}
+
+/**
+ * The timestamp a pause of `minutes` ends at, or `null` for no pause. Stored
+ * rather than counted down in memory, so a restart in the middle of a pause
+ * does not resume claiming early.
+ */
+export function pauseUntil(minutes: number, now = Date.now()): number | null {
+  return minutes > 0 ? now + minutes * MINUTE_MS : null;
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -240,7 +240,29 @@ export async function reloadAgent(servers: UpstreamServer[]): Promise<void> {
   startAgent(servers);
 }
 
-/** Called after the Servers page saves, so a change takes effect at once. */
+/**
+ * Called after the Servers page saves, so a change takes effect at once.
+ *
+ * A running loop is handed the new list instead of being restarted. Restarting
+ * means waiting for the loop to leave the job it is in, which is up to
+ * `JOB_TIMEOUT_MS` of a page that looks hung — and nothing needs the wait:
+ * only starting a second loop alongside the first would double-claim, and
+ * swapping a list in place never does that. The job in flight finishes against
+ * the server it was claimed from, which it holds a reference to.
+ */
 export async function applyUpstreamChange(): Promise<void> {
-  await reloadAgent(activeUpstreams(await loadSettings()));
+  const servers = activeUpstreams(await loadSettings());
+
+  // Nothing is running, so there is no loop to hand it to.
+  if (!running) {
+    await reloadAgent(servers);
+    return;
+  }
+
+  upstreams = servers;
+  heartbeats.clear();
+
+  // Nothing left to claim from. Heartbeats stop now; the job in flight still
+  // reports back, because it carries its own server.
+  if (servers.length === 0) stopAgent();
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,11 +5,13 @@ import {
   AUTO_UPDATE,
   COMFY_URL,
   HEARTBEAT_INTERVAL_MS,
+  JOB_RETRIES,
   POLL_INTERVAL_MS,
+  RETRY_DELAY_MS,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./config";
 import { pushEvent } from "./events";
-import { completeJob, failJob, markQueued, startJob } from "./jobs";
+import { completeJob, failJob, markQueued, noteAttempt, startJob } from "./jobs";
 import { latestStatus, refreshStatus } from "./status";
 import { RESTART_EXIT_CODE, remoteHasUpdate } from "./updater";
 import { loadSettings } from "./settings";
@@ -113,39 +115,64 @@ async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
     workflow: workflowName,
   });
 
-  try {
-    let imageFilename: string | undefined;
-    if (claimed.sourceImageBase64) {
-      const contentType = claimed.sourceImageContentType || "image/png";
-      const ext = contentType.split("/")[1] ?? "png";
-      imageFilename = await uploadImage(
-        COMFY_URL,
-        `input_${claimed.jobId}.${ext}`,
-        contentType,
-        Buffer.from(claimed.sourceImageBase64, "base64"),
+  // A transient failure — a network blip, ComfyUI mid-restart — gets retried
+  // on this machine before the job server hears anything: the job is claimed
+  // and would not be handed out again anyway. Only claimed jobs retry; a run
+  // from the UI has someone watching it, who would not expect a quiet rerun.
+  const tries = 1 + JOB_RETRIES;
+
+  for (let attempt = 1; ; attempt++) {
+    if (attempt > 1) noteAttempt(job, attempt);
+
+    try {
+      let imageFilename: string | undefined;
+      if (claimed.sourceImageBase64) {
+        const contentType = claimed.sourceImageContentType || "image/png";
+        const ext = contentType.split("/")[1] ?? "png";
+        // The name repeats across attempts and the upload overwrites, so a
+        // retry cannot litter ComfyUI's input folder.
+        imageFilename = await uploadImage(
+          COMFY_URL,
+          `input_${claimed.jobId}.${ext}`,
+          contentType,
+          Buffer.from(claimed.sourceImageBase64, "base64"),
+        );
+        console.log(`[worker] uploaded input image → ${imageFilename}`);
+      }
+
+      const outputs = await runWorkflow(
+        workflowName,
+        { ...claimed.params, imageFilename },
+        (promptId) => markQueued(job, promptId),
       );
-      console.log(`[worker] uploaded input image → ${imageFilename}`);
+
+      // Upstreams expect a single artefact. Video workflows also emit preview
+      // images, so prefer a playable file over whatever happens to come first.
+      const primary = outputs.find((output) => output.kind === "video") ?? outputs[0]!;
+      await uploadResult(server, claimed.jobId, primary.url);
+      await reportComplete(server, claimed.jobId);
+
+      completeJob(job, outputs);
+      console.log(`[worker] job ${claimed.jobId} completed`);
+      return;
+    } catch (err) {
+      const reason = message(err);
+
+      if (attempt < tries && running) {
+        console.error(
+          `[worker] job ${claimed.jobId} attempt ${attempt}/${tries} failed: ${reason}` +
+            ` — retrying in ${Math.round(RETRY_DELAY_MS / 1000)} s`,
+        );
+        await idle(RETRY_DELAY_MS);
+        // The agent was stopped mid-wait; report rather than run on regardless.
+        if (running) continue;
+      }
+
+      console.error(`[worker] job ${claimed.jobId} failed: ${reason}`);
+      failJob(job, reason);
+      await reportFailure(server, claimed.jobId, reason);
+      return;
     }
-
-    const outputs = await runWorkflow(
-      workflowName,
-      { ...claimed.params, imageFilename },
-      (promptId) => markQueued(job, promptId),
-    );
-
-    // Upstreams expect a single artefact. Video workflows also emit preview
-    // images, so prefer a playable file over whatever happens to come first.
-    const primary = outputs.find((output) => output.kind === "video") ?? outputs[0]!;
-    await uploadResult(server, claimed.jobId, primary.url);
-    await reportComplete(server, claimed.jobId);
-
-    completeJob(job, outputs);
-    console.log(`[worker] job ${claimed.jobId} completed`);
-  } catch (err) {
-    const reason = message(err);
-    console.error(`[worker] job ${claimed.jobId} failed: ${reason}`);
-    failJob(job, reason);
-    await reportFailure(server, claimed.jobId, reason);
   }
 }
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -8,6 +8,7 @@ import {
   POLL_INTERVAL_MS,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./config";
+import { pushEvent } from "./events";
 import { completeJob, failJob, markQueued, startJob } from "./jobs";
 import { latestStatus, refreshStatus } from "./status";
 import { RESTART_EXIT_CODE, remoteHasUpdate } from "./updater";
@@ -60,12 +61,17 @@ async function sendHeartbeats() {
 
   await Promise.all(
     upstreams.map(async (server) => {
+      // What the last beat said, so only a change of state is announced.
+      const was = heartbeats.get(server.name)?.ok;
+
       const ack = await sendHeartbeat(server, status);
       if (!ack) {
         heartbeats.set(server.name, { ok: false, at: Date.now() });
+        if (was !== false) pushEvent("upstream-down", { server: server.name });
         return;
       }
       heartbeats.set(server.name, { ok: true, at: Date.now(), pendingJobs: ack.pendingJobs });
+      if (was === false) pushEvent("upstream-up", { server: server.name });
       const backlog =
         ack.pendingJobs === undefined ? "" : ` | upstream queue: ${ack.pendingJobs} waiting`;
       console.log(

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { acceptState } from "./accepting";
 import { uploadImage } from "./comfy";
 import {
   AUTO_UPDATE,
@@ -177,10 +178,10 @@ async function runPoll() {
       }
     }
 
-    // Only the first mode claims. Heartbeats carry on either way, so the
-    // upstream still sees this host as alive — its queue simply is not drained
-    // from here.
-    if ((await loadSettings()).mode !== "accepting") {
+    // Only the first mode claims, and a pause or a daily window can withhold
+    // it further. Heartbeats carry on through all of it, so the upstream still
+    // sees this host as alive — its queue simply is not drained from here.
+    if (!acceptState(await loadSettings()).accepting) {
       await idle(POLL_INTERVAL_MS);
       continue;
     }

--- a/src/comfy-process.ts
+++ b/src/comfy-process.ts
@@ -104,7 +104,7 @@ export async function startComfy(): Promise<void> {
 
   const settings = await loadSettings();
   if (!settings.comfyDir) {
-    throw new Error("set the ComfyUI directory on the Settings page first");
+    throw new Error("set the ComfyUI directory on the ComfyUI page first");
   }
   if (!existsSync(settings.comfyDir)) {
     throw new Error(`no such directory: ${settings.comfyDir}`);

--- a/src/comfy-process.ts
+++ b/src/comfy-process.ts
@@ -11,6 +11,10 @@
  * request can only say "start" or "stop" — it cannot say what to run. That
  * still means anyone who can reach the management UI can run the configured
  * command, which is why the UI binds to 127.0.0.1 unless you change it.
+ *
+ * A managed child that dies without being asked is restarted (see the watchdog
+ * constants below); only `stopComfy` — the Stop buttons and the Stopped mode —
+ * counts as being asked.
  */
 
 import { existsSync } from "node:fs";
@@ -33,10 +37,27 @@ export type ComfyProcessState = {
 
 const LOG_LINES = 40;
 
+/**
+ * The watchdog. A machine that serves jobs unattended is only as reliable as
+ * the ComfyUI under it, so a managed child that dies without being asked is
+ * started again. A child that keeps dying moments after starting is a broken
+ * command, not a hiccup — after three of those in a row it stops trying, and
+ * the log holds the reason.
+ */
+const RESTART_DELAY_MS = 5000;
+const FAST_FAIL_MS = 60_000;
+const MAX_FAST_FAILS = 3;
+
 let child: Bun.Subprocess | null = null;
 let startedAt: number | null = null;
 let lastError: string | null = null;
 const log: string[] = [];
+
+/** True between a successful start and a requested stop: "keep it running". */
+let wanted = false;
+let restartTimer: ReturnType<typeof setTimeout> | null = null;
+/** Consecutive deaths within {@link FAST_FAIL_MS} of starting. */
+let fastFails = 0;
 
 function note(line: string): void {
   for (const part of line.split("\n")) {
@@ -115,22 +136,30 @@ export async function startComfy(): Promise<void> {
 
   log.length = 0;
   lastError = null;
+  fastFails = 0;
+  wanted = true;
+  launch(command, settings.comfyDir);
+}
+
+function launch(command: string[], dir: string): void {
   note(`$ ${command.join(" ")}`);
 
   const spawned = Bun.spawn(command, {
-    cwd: settings.comfyDir,
+    cwd: dir,
     stdout: "pipe",
     stderr: "pipe",
     onExit(_proc, exitCode, signalCode) {
       note(`— exited (code ${exitCode ?? "null"}${signalCode ? `, ${signalCode}` : ""})`);
+      if (child !== spawned) return;
+
+      const uptime = Date.now() - (startedAt ?? Date.now());
+      child = null;
+      startedAt = null;
       // A non-zero exit with nothing asked of it is a failure worth surfacing.
-      if (child === spawned && exitCode !== 0 && signalCode === null) {
+      if (exitCode !== 0 && signalCode === null) {
         lastError = `ComfyUI exited with code ${exitCode}`;
       }
-      if (child === spawned) {
-        child = null;
-        startedAt = null;
-      }
+      maybeRestart(uptime);
     },
   });
 
@@ -139,6 +168,49 @@ export async function startComfy(): Promise<void> {
 
   void drain(spawned.stdout);
   void drain(spawned.stderr);
+}
+
+/** Called with how long the child lived, after every exit nobody asked for. */
+function maybeRestart(uptimeMs: number): void {
+  if (!wanted) return;
+
+  // A death after a long run gets a fresh allowance; one right after starting
+  // spends it.
+  fastFails = uptimeMs < FAST_FAIL_MS ? fastFails + 1 : 1;
+
+  if (fastFails > MAX_FAST_FAILS) {
+    wanted = false;
+    lastError = "ComfyUI keeps crashing right after starting — not restarting, check the log";
+    note(`— ${lastError}`);
+    return;
+  }
+
+  note(`— restarting in ${RESTART_DELAY_MS / 1000} s (crash ${fastFails}/${MAX_FAST_FAILS})`);
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    void restart();
+  }, RESTART_DELAY_MS);
+}
+
+/**
+ * The automatic path back up. Unlike {@link startComfy} it keeps the log, so
+ * the crash that caused it stays readable, and it re-reads the settings so a
+ * directory fixed in the meantime is what gets run.
+ */
+async function restart(): Promise<void> {
+  // Someone pressed Stop during the delay, or Start beat the timer to it.
+  if (!wanted || child) return;
+
+  const settings = await loadSettings();
+  const command = resolveCommand(settings.comfyDir, settings.comfyCommand);
+  if (!settings.comfyDir || !existsSync(settings.comfyDir) || command.length === 0) {
+    wanted = false;
+    lastError = "cannot restart ComfyUI — the directory or command is gone";
+    note(`— ${lastError}`);
+    return;
+  }
+
+  launch(command, settings.comfyDir);
 }
 
 async function drain(stream: ReadableStream<Uint8Array> | number | undefined): Promise<void> {
@@ -152,6 +224,13 @@ async function drain(stream: ReadableStream<Uint8Array> | number | undefined): P
  * two; a model still loading can take longer than anyone wants to wait.
  */
 export async function stopComfy(): Promise<void> {
+  // Asked to stop, so an exit is no longer something to undo.
+  wanted = false;
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+
   const running = child;
   if (!running) return;
 

--- a/src/comfy-process.ts
+++ b/src/comfy-process.ts
@@ -19,6 +19,7 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { pushEvent } from "./events";
 import { loadSettings } from "./settings";
 
 export type ComfyProcessState = {
@@ -182,10 +183,12 @@ function maybeRestart(uptimeMs: number): void {
     wanted = false;
     lastError = "ComfyUI keeps crashing right after starting — not restarting, check the log";
     note(`— ${lastError}`);
+    pushEvent("comfy-gave-up");
     return;
   }
 
   note(`— restarting in ${RESTART_DELAY_MS / 1000} s (crash ${fastFails}/${MAX_FAST_FAILS})`);
+  pushEvent("comfy-crashed");
   restartTimer = setTimeout(() => {
     restartTimer = null;
     void restart();

--- a/src/comfy.ts
+++ b/src/comfy.ts
@@ -1,13 +1,36 @@
 import { CLIENT_ID } from "./progress";
 import type { ApiWorkflow } from "./slots";
-import type { ComfyStatusResult, OutputKind, RunOutput } from "./types";
+import type { ComfyStatusResult, GpuStatus, OutputKind, RunOutput } from "./types";
 
 type ComfyQueueResponse = {
   queue_running?: unknown[];
   queue_pending?: unknown[];
 };
 
-/** Reachability plus queue depth, used for heartbeats and the UI header. */
+type SystemStats = {
+  devices?: {
+    name?: string;
+    type?: string;
+    vram_total?: number;
+    vram_free?: number;
+  }[];
+};
+
+/** The first device that is not the CPU — the one the models actually load on. */
+function firstGpu(stats: SystemStats): GpuStatus | null {
+  const device = stats.devices?.find((entry) => entry.type !== "cpu");
+  if (
+    !device ||
+    typeof device.vram_total !== "number" ||
+    typeof device.vram_free !== "number" ||
+    device.vram_total <= 0
+  ) {
+    return null;
+  }
+  return { name: device.name ?? "GPU", vramTotal: device.vram_total, vramFree: device.vram_free };
+}
+
+/** Reachability, queue depth and VRAM, used for heartbeats and the UI header. */
 export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
   try {
     const signal = AbortSignal.timeout(5000);
@@ -17,9 +40,10 @@ export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
     ]);
 
     if (!statsRes.ok || !queueRes.ok) {
-      return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0 };
+      return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0, gpu: null };
     }
 
+    const stats = (await statsRes.json()) as SystemStats;
     const queue = (await queueRes.json()) as ComfyQueueResponse;
     const queueRunning = queue.queue_running?.length ?? 0;
     const queuePending = queue.queue_pending?.length ?? 0;
@@ -28,9 +52,10 @@ export async function checkComfy(baseUrl: string): Promise<ComfyStatusResult> {
       comfyStatus: queueRunning > 0 ? "busy" : "available",
       queueRunning,
       queuePending,
+      gpu: firstGpu(stats),
     };
   } catch {
-    return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0 };
+    return { comfyStatus: "unavailable", queueRunning: 0, queuePending: 0, gpu: null };
   }
 }
 

--- a/src/comfy.ts
+++ b/src/comfy.ts
@@ -1,3 +1,4 @@
+import { CLIENT_ID } from "./progress";
 import type { ApiWorkflow } from "./slots";
 import type { ComfyStatusResult, OutputKind, RunOutput } from "./types";
 
@@ -76,7 +77,9 @@ export async function queuePrompt(baseUrl: string, workflow: ApiWorkflow): Promi
   const res = await fetch(`${baseUrl}/prompt`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ prompt: workflow }),
+    // The client id is what makes ComfyUI address its progress messages at the
+    // socket in `progress.ts` rather than at nobody.
+    body: JSON.stringify({ prompt: workflow, client_id: CLIENT_ID }),
     signal: AbortSignal.timeout(30_000),
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,14 @@ export const HEARTBEAT_INTERVAL_MS = Number(process.env.HEARTBEAT_INTERVAL_MS ??
 /** How long a single ComfyUI run may take before it is abandoned. */
 export const JOB_TIMEOUT_MS = Number(process.env.JOB_TIMEOUT_MS ?? "600000");
 
+/**
+ * Extra tries an upstream job gets on this machine before its failure is
+ * reported. A transient failure — a network blip, ComfyUI mid-restart — is
+ * cheaper to retry here than to bounce back through the job server.
+ */
+export const JOB_RETRIES = Number(process.env.JOB_RETRIES ?? "2");
+export const RETRY_DELAY_MS = Number(process.env.RETRY_DELAY_MS ?? "10000");
+
 export const AUTO_UPDATE = (process.env.AUTO_UPDATE ?? "false") !== "false";
 export const UPDATE_CHECK_INTERVAL_MS = Number(process.env.UPDATE_CHECK_INTERVAL_MS ?? "60000");
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,7 +14,8 @@ export type UiEventKind =
   | "upstream-down"
   | "upstream-up"
   | "comfy-crashed"
-  | "comfy-gave-up";
+  | "comfy-gave-up"
+  | "outputs-trimmed";
 
 export type UiEvent = {
   id: number;

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,41 @@
+/**
+ * Things worth telling a person about, kept as a small ring the UI reads from
+ * `/api/state` and turns into OS notifications.
+ *
+ * The server records facts — kind and parameters — and whoever displays them
+ * writes the sentence, in the reader's language. Ids are time-based so a
+ * watcher's "seen up to here" survives this process restarting; the ring is
+ * short because anything older is history, and history is what the log and the
+ * Runs page are for.
+ */
+
+export type UiEventKind =
+  | "job-failed"
+  | "upstream-down"
+  | "upstream-up"
+  | "comfy-crashed"
+  | "comfy-gave-up";
+
+export type UiEvent = {
+  id: number;
+  at: number;
+  kind: UiEventKind;
+  /** What the event is about — workflow, server name, error — for the message. */
+  params: Record<string, string>;
+};
+
+const MAX_EVENTS = 20;
+
+const events: UiEvent[] = [];
+let nextId = 0;
+
+export function pushEvent(kind: UiEventKind, params: Record<string, string> = {}): void {
+  // Monotonic and larger than any id a previous run handed out.
+  nextId = Math.max(nextId + 1, Date.now());
+  events.push({ id: nextId, at: Date.now(), kind, params });
+  if (events.length > MAX_EVENTS) events.splice(0, events.length - MAX_EVENTS);
+}
+
+export function listEvents(): UiEvent[] {
+  return events;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { startAgent, stopAgent } from "./agent";
 import { startComfyWatch, stopComfy } from "./comfy-process";
 import { COMFY_URL, DATA_DIR, UI_ENABLED, WORKFLOW_DIR } from "./config";
 import { loadJobs } from "./jobs";
+import { startOutputWatch } from "./outputs";
 import { startProgressWatch, stopProgressWatch } from "./progress";
 import { loadSettings } from "./settings";
 import { startStatusPolling } from "./status";
@@ -37,6 +38,7 @@ if (names.length === 0) {
 
 const statusTimer = startStatusPolling(STATUS_POLL_MS);
 const comfyWatch = startComfyWatch();
+const outputWatch = startOutputWatch();
 startProgressWatch();
 
 if (UI_ENABLED) {
@@ -56,6 +58,7 @@ function shutdown() {
   stopAgent();
   clearInterval(statusTimer);
   clearInterval(comfyWatch);
+  clearInterval(outputWatch);
   stopProgressWatch();
   void stopComfy();
   process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { startAgent, stopAgent } from "./agent";
 import { startComfyWatch, stopComfy } from "./comfy-process";
 import { COMFY_URL, DATA_DIR, UI_ENABLED, WORKFLOW_DIR } from "./config";
 import { loadJobs } from "./jobs";
+import { startProgressWatch, stopProgressWatch } from "./progress";
 import { loadSettings } from "./settings";
 import { startStatusPolling } from "./status";
 import { startUi } from "./ui/server";
@@ -36,6 +37,7 @@ if (names.length === 0) {
 
 const statusTimer = startStatusPolling(STATUS_POLL_MS);
 const comfyWatch = startComfyWatch();
+startProgressWatch();
 
 if (UI_ENABLED) {
   const server = startUi();
@@ -54,6 +56,7 @@ function shutdown() {
   stopAgent();
   clearInterval(statusTimer);
   clearInterval(comfyWatch);
+  stopProgressWatch();
   void stopComfy();
   process.exit(0);
 }

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -9,6 +9,7 @@
 
 import { readFile, writeFile } from "node:fs/promises";
 import { JOBS_FILE } from "./config";
+import { pushEvent } from "./events";
 import type { JobRecord, JobSource, RunOutput } from "./types";
 
 const MAX_JOBS = 200;
@@ -83,6 +84,8 @@ export function failJob(job: JobRecord, error: string): void {
   job.error = error;
   job.finishedAt = Date.now();
   persist();
+  // Cut for a notification body, not for the record: `job.error` keeps it all.
+  pushEvent("job-failed", { workflow: job.workflow, error: error.slice(0, 200) });
 }
 
 export function listJobs(): JobRecord[] {

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -72,6 +72,12 @@ export function markQueued(job: JobRecord, promptId: string): void {
   persist();
 }
 
+/** Records that the job is on its `attempt`-th try, so the UI can say so. */
+export function noteAttempt(job: JobRecord, attempt: number): void {
+  job.attempts = attempt;
+  persist();
+}
+
 export function completeJob(job: JobRecord, outputs: RunOutput[]): void {
   job.state = "succeeded";
   job.outputs = outputs;

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -1,0 +1,144 @@
+/**
+ * ComfyUI's output folder, watched and trimmed.
+ *
+ * Video workflows fill the disk quietly — nothing in ComfyUI ever deletes an
+ * output. This keeps a cheap running total (files and bytes) for the UI, and
+ * deletes files older than a chosen age: on demand from a button, and on a
+ * timer when `outputCleanupDays` is set.
+ *
+ * Only files under the output directory are ever touched, and directories are
+ * left in place. The scan is cached and redone on a slow timer rather than per
+ * request — the UI polls every two seconds, and a large folder should not be
+ * walked at that pace.
+ */
+
+import { existsSync } from "node:fs";
+import { readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { pushEvent } from "./events";
+import { loadSettings } from "./settings";
+
+const SCAN_INTERVAL_MS = 10 * 60_000;
+const DAY_MS = 86_400_000;
+
+export type OutputsSnapshot = {
+  dir: string;
+  files: number;
+  bytes: number;
+  scannedAt: number;
+};
+
+let snapshot: OutputsSnapshot | null = null;
+
+/**
+ * Where ComfyUI writes its outputs, mirroring how `resolveCommand` reads the
+ * directory: the portable bundle keeps ComfyUI one level down.
+ */
+export function outputDirFor(comfyDir: string): string | null {
+  if (!comfyDir) return null;
+  const portable = join(comfyDir, "ComfyUI", "output");
+  if (existsSync(portable)) return portable;
+  const plain = join(comfyDir, "output");
+  return existsSync(plain) ? plain : null;
+}
+
+async function walk(
+  dir: string,
+  visit: (path: string, size: number, mtimeMs: number) => void,
+): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(path, visit);
+    } else if (entry.isFile()) {
+      const stats = await stat(path).catch(() => null);
+      if (stats) visit(path, stats.size, stats.mtimeMs);
+    }
+  }
+}
+
+export function outputsSnapshot(): OutputsSnapshot | null {
+  return snapshot;
+}
+
+export async function rescanOutputs(): Promise<OutputsSnapshot | null> {
+  const dir = outputDirFor((await loadSettings()).comfyDir);
+  if (!dir) {
+    snapshot = null;
+    return null;
+  }
+
+  let files = 0;
+  let bytes = 0;
+  await walk(dir, (_path, size) => {
+    files += 1;
+    bytes += size;
+  });
+
+  snapshot = { dir, files, bytes, scannedAt: Date.now() };
+  return snapshot;
+}
+
+/** "3.2 GB" or "410 MB" — for logs and notifications, not for the record. */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+/**
+ * Delete every file older than `days` under the output folder. A file that
+ * refuses to go — held open by a player, say — is skipped, not fatal: the next
+ * sweep gets another chance at it.
+ */
+export async function trimOutputs(
+  days: number,
+): Promise<{ removedFiles: number; removedBytes: number }> {
+  const dir = outputDirFor((await loadSettings()).comfyDir);
+  if (!dir) throw new Error("no output folder found — set the ComfyUI directory first");
+
+  const cutoff = Date.now() - days * DAY_MS;
+  const doomed: { path: string; size: number }[] = [];
+  await walk(dir, (path, size, mtimeMs) => {
+    if (mtimeMs < cutoff) doomed.push({ path, size });
+  });
+
+  let removedFiles = 0;
+  let removedBytes = 0;
+  for (const file of doomed) {
+    try {
+      await rm(file.path);
+      removedFiles += 1;
+      removedBytes += file.size;
+    } catch {
+      // Skipped this sweep; it stays in the count the rescan reports.
+    }
+  }
+
+  await rescanOutputs();
+  return { removedFiles, removedBytes };
+}
+
+/** One pass of the timer: apply the stored rule, or just refresh the count. */
+async function sweep(): Promise<void> {
+  const settings = await loadSettings();
+
+  if (settings.outputCleanupDays > 0 && outputDirFor(settings.comfyDir)) {
+    const { removedFiles, removedBytes } = await trimOutputs(settings.outputCleanupDays);
+    if (removedFiles > 0) {
+      console.log(`[outputs] removed ${removedFiles} file(s), ${formatBytes(removedBytes)}`);
+      pushEvent("outputs-trimmed", {
+        files: String(removedFiles),
+        size: formatBytes(removedBytes),
+      });
+    }
+    return; // trimOutputs rescanned already
+  }
+
+  await rescanOutputs();
+}
+
+export function startOutputWatch(): ReturnType<typeof setInterval> {
+  void sweep();
+  return setInterval(() => void sweep(), SCAN_INTERVAL_MS);
+}

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,145 @@
+/**
+ * How far along the run in flight is, read from ComfyUI's WebSocket.
+ *
+ * Over HTTP there are two facts and nothing between them: a prompt was queued,
+ * and later it was done. A run that takes minutes therefore looks the same at
+ * 5% as at 95%, which is the difference between slow and stuck. ComfyUI does
+ * say — over `/ws`, addressed to the client id the prompt was queued with — so
+ * prompts go out carrying {@link CLIENT_ID} and this listens as that client.
+ *
+ * All of it is best effort. A socket that drops takes no run with it: the prompt
+ * belongs to ComfyUI by then, and the only loss is hearing about steps until the
+ * reconnect lands.
+ */
+
+import { COMFY_URL } from "./config";
+
+/** This process, to ComfyUI: on the prompt body and on the socket alike. */
+export const CLIENT_ID = crypto.randomUUID();
+
+const RECONNECT_MS = 5000;
+
+/**
+ * Progress this old is not progress. ComfyUI says when a run ends, but a socket
+ * that died mid-run says nothing at all, and a bar frozen at 60% is worse than
+ * no bar.
+ */
+const STALE_MS = 60_000;
+
+export type RunProgress = {
+  /** Empty when ComfyUI did not name one; the UI then shows no bar. */
+  promptId: string;
+  /** Steps done and steps expected, as ComfyUI counts them. */
+  value: number;
+  max: number;
+  /** The node being executed, when a message named it. */
+  node: string | null;
+  at: number;
+};
+
+let latest: RunProgress | null = null;
+let socket: WebSocket | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let watching = false;
+
+export function latestProgress(): RunProgress | null {
+  if (latest && Date.now() - latest.at > STALE_MS) latest = null;
+  return latest;
+}
+
+type Message = {
+  type?: string;
+  data?: {
+    value?: number;
+    max?: number;
+    node?: string | null;
+    prompt_id?: string;
+  };
+};
+
+/** Unknown message types are ignored: ComfyUI sends plenty this does not need. */
+function handle(raw: string): void {
+  let message: Message;
+  try {
+    message = JSON.parse(raw) as Message;
+  } catch {
+    return;
+  }
+  const data = message.data ?? {};
+
+  switch (message.type) {
+    case "progress": {
+      if (typeof data.value !== "number" || typeof data.max !== "number") return;
+      latest = {
+        promptId: data.prompt_id ?? latest?.promptId ?? "",
+        value: data.value,
+        max: data.max,
+        node: data.node ?? null,
+        at: Date.now(),
+      };
+      return;
+    }
+
+    // A node started, or — with no node — the queue went quiet. The step count
+    // belonged to the node that just ended either way, so it is dropped.
+    case "executing": {
+      if (data.node === null || data.node === undefined) latest = null;
+      else if (latest) latest = { ...latest, node: data.node, at: Date.now() };
+      return;
+    }
+
+    case "execution_success":
+    case "execution_error":
+    case "execution_interrupted":
+      latest = null;
+      return;
+
+    default:
+      return;
+  }
+}
+
+function connect(): void {
+  if (!watching) return;
+
+  const retry = (): void => {
+    socket = null;
+    latest = null;
+    // ComfyUI being down is the normal case here rather than an error, so this
+    // says nothing and simply comes back. `timer` also makes the pair of events
+    // a failed connect fires — error, then close — schedule one attempt.
+    if (!watching || timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      connect();
+    }, RECONNECT_MS);
+  };
+
+  try {
+    socket = new WebSocket(`${COMFY_URL.replace(/^http/, "ws")}/ws?clientId=${CLIENT_ID}`);
+  } catch {
+    retry();
+    return;
+  }
+
+  socket.addEventListener("message", (event) => {
+    if (typeof event.data === "string") handle(event.data);
+  });
+  socket.addEventListener("close", retry);
+  socket.addEventListener("error", retry);
+}
+
+export function startProgressWatch(): void {
+  if (watching) return;
+  watching = true;
+  connect();
+}
+
+export function stopProgressWatch(): void {
+  watching = false;
+  if (timer) clearTimeout(timer);
+  timer = null;
+  socket?.close();
+  socket = null;
+  latest = null;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@
  */
 
 import { readFile, writeFile } from "node:fs/promises";
+import { isTimeOfDay } from "./accepting";
 import { STATE_FILE } from "./config";
 
 export type UpstreamConfig = {
@@ -50,6 +51,20 @@ export type RunMode =
 
 export const RUN_MODES: RunMode[] = ["accepting", "local", "paused"];
 
+/**
+ * The daily window in which job servers get work out of this machine. Off on a
+ * fresh install: a machine that is running accepts, which is the behaviour
+ * everyone had before there was a window at all.
+ */
+export type AcceptSchedule = {
+  enabled: boolean;
+  /** Local `HH:MM`. An end before the start crosses midnight. */
+  from: string;
+  to: string;
+};
+
+const EMPTY_SCHEDULE: AcceptSchedule = { enabled: false, from: "02:00", to: "08:00" };
+
 export type Settings = {
   activeWorkflow: string | null;
   /** Where ComfyUI is checked out. Empty until someone fills it in. */
@@ -65,6 +80,14 @@ export type Settings = {
    * up quietly claiming jobs again is the surprising behaviour.
    */
   mode: RunMode;
+  /** When the mode above is allowed to claim. */
+  schedule: AcceptSchedule;
+  /**
+   * Claiming is off until this timestamp, `null` when it is not. A stored
+   * deadline rather than a countdown, so a restart inside the pause does not
+   * quietly start claiming again.
+   */
+  pauseUntil: number | null;
   desktop: DesktopSettings;
 };
 
@@ -74,6 +97,8 @@ const EMPTY: Settings = {
   comfyCommand: "",
   upstreams: [],
   mode: "accepting",
+  schedule: EMPTY_SCHEDULE,
+  pauseUntil: null,
   desktop: { autostart: false, closeAction: "tray" },
 };
 
@@ -132,6 +157,18 @@ function normaliseMode(value: Partial<Settings> & { accepting?: unknown }): RunM
   return "accepting";
 }
 
+function normaliseSchedule(raw: unknown): AcceptSchedule {
+  const value = (raw ?? {}) as Partial<AcceptSchedule>;
+  return {
+    enabled: value.enabled === true,
+    // A time the file cannot describe falls back to the default rather than
+    // failing the load: the window is off by default, so nothing is lent out
+    // on a value nobody typed.
+    from: isTimeOfDay(value.from) ? value.from : EMPTY_SCHEDULE.from,
+    to: isTimeOfDay(value.to) ? value.to : EMPTY_SCHEDULE.to,
+  };
+}
+
 function normaliseDesktop(raw: unknown): DesktopSettings {
   const value = (raw ?? {}) as Partial<DesktopSettings>;
   return {
@@ -152,6 +189,8 @@ function normalise(raw: unknown): Settings {
     // missing key falls back to the environment.
     upstreams: upstreams ?? upstreamsFromEnv(),
     mode: normaliseMode(value),
+    schedule: normaliseSchedule(value.schedule),
+    pauseUntil: typeof value.pauseUntil === "number" ? value.pauseUntil : null,
     desktop: normaliseDesktop(value.desktop),
   };
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -140,7 +140,8 @@ function upstreamsFromEnv(): UpstreamConfig[] {
   return servers;
 }
 
-function hostFromUrl(url: string): string {
+/** The label a server gets when nobody named it: what its URL calls itself. */
+export function hostFromUrl(url: string): string {
   try {
     return new URL(url).host;
   } catch {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -88,6 +88,11 @@ export type Settings = {
    * quietly start claiming again.
    */
   pauseUntil: number | null;
+  /**
+   * Outputs older than this many days are deleted by the sweep in
+   * `outputs.ts`. `0` — the default — means never delete anything.
+   */
+  outputCleanupDays: number;
   desktop: DesktopSettings;
 };
 
@@ -99,6 +104,7 @@ const EMPTY: Settings = {
   mode: "accepting",
   schedule: EMPTY_SCHEDULE,
   pauseUntil: null,
+  outputCleanupDays: 0,
   desktop: { autostart: false, closeAction: "tray" },
 };
 
@@ -170,6 +176,13 @@ function normaliseSchedule(raw: unknown): AcceptSchedule {
   };
 }
 
+/** Anything a day count cannot be — negative, NaN, absent — means "off". */
+export function normaliseCleanupDays(raw: unknown): number {
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 1
+    ? Math.min(3650, Math.floor(raw))
+    : 0;
+}
+
 function normaliseDesktop(raw: unknown): DesktopSettings {
   const value = (raw ?? {}) as Partial<DesktopSettings>;
   return {
@@ -192,6 +205,7 @@ function normalise(raw: unknown): Settings {
     mode: normaliseMode(value),
     schedule: normaliseSchedule(value.schedule),
     pauseUntil: typeof value.pauseUntil === "number" ? value.pauseUntil : null,
+    outputCleanupDays: normaliseCleanupDays(value.outputCleanupDays),
     desktop: normaliseDesktop(value.desktop),
   };
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -10,6 +10,7 @@ let latest: ComfyStatusResult = {
   comfyStatus: "unavailable",
   queueRunning: 0,
   queuePending: 0,
+  gpu: null,
 };
 let checkedAt = 0;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,8 @@ export type JobRecord = {
   promptId?: string;
   outputs?: RunOutput[];
   error?: string;
+  /** Tries this job has had on this machine; absent means the first. */
+  attempts?: number;
   /**
    * The process died while this job was running. Flagged rather than left to
    * `error` alone so the UI can say it in the reader's own language.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,22 @@
 export type ComfyStatus = "available" | "busy" | "unavailable";
 
+/**
+ * The GPU as ComfyUI reports it, in bytes. Read through ComfyUI rather than
+ * from this machine, so a remote `COMFY_URL` shows the GPU actually doing the
+ * work.
+ */
+export type GpuStatus = {
+  name: string;
+  vramTotal: number;
+  vramFree: number;
+};
+
 export type ComfyStatusResult = {
   comfyStatus: ComfyStatus;
   queueRunning: number;
   queuePending: number;
+  /** `null` when ComfyUI is unreachable or reported no GPU device. */
+  gpu: GpuStatus | null;
 };
 
 export type OutputKind = "image" | "video" | "audio" | "file";

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -472,6 +472,36 @@ function slotTags(summary: WorkflowSummary): string {
   return `<div class="slots">${tags.join("")}</div>`;
 }
 
+/**
+ * The last check of each workflow against the running ComfyUI, held here the
+ * way server test results are held on their rows. Nothing until one is run.
+ */
+type WorkflowCheck = { checking?: boolean; ok?: boolean; problems?: string[]; error?: string };
+const workflowChecks = new Map<string, WorkflowCheck>();
+
+function checkResultFor(name: string): string {
+  const check = workflowChecks.get(name);
+  if (!check) return "";
+  if (check.checking) return `<p class="meta">${t("workflows.checking")}</p>`;
+  if (check.error) return `<p class="error">${esc(check.error)}</p>`;
+  if (check.ok) return `<p class="meta">${t("workflows.checkOk")}</p>`;
+  return (check.problems ?? []).map((problem) => `<p class="error">${esc(problem)}</p>`).join("");
+}
+
+async function runWorkflowCheck(name: string): Promise<void> {
+  workflowChecks.set(name, { checking: true });
+  if (latestState) renderWorkflows(latestState);
+
+  const result = await post<{ ok: boolean; problems: string[] }>("/api/workflows/check", { name });
+  workflowChecks.set(
+    name,
+    result.ok
+      ? { ok: result.data?.ok ?? false, problems: result.data?.problems ?? [] }
+      : { error: result.error ?? t("workflows.checkFailed") },
+  );
+  if (latestState) renderWorkflows(latestState);
+}
+
 function renderWorkflows(state: State): void {
   nodes.workflowDir.textContent = t("workflows.dir", { dir: state.workflowDir });
 
@@ -489,6 +519,11 @@ function renderWorkflows(state: State): void {
           ${active ? `<span class="state"><span class="dot run"></span>${t("workflows.active")}</span>` : ""}
           <span class="spacer"></span>
           ${
+            summary.valid
+              ? `<button type="button" class="ghost" data-check-workflow="${esc(summary.name)}">${t("workflows.check")}</button>`
+              : ""
+          }
+          ${
             active || !summary.valid
               ? ""
               : `<button type="button" class="ghost" data-activate="${esc(summary.name)}">${t("workflows.makeActive")}</button>`
@@ -504,6 +539,7 @@ function renderWorkflows(state: State): void {
         ${head}
         <p class="meta">${t("workflows.nodes", { count: summary.nodeCount ?? 0 })}</p>
         ${slotTags(summary)}
+        ${checkResultFor(summary.name)}
       </div>`;
     })
     .join("");
@@ -1403,6 +1439,12 @@ nodes.uploadForm.addEventListener("submit", async (event) => {
 
 nodes.workflows.addEventListener("click", async (event) => {
   const target = event.target as HTMLElement;
+
+  const check = target.closest<HTMLElement>("[data-check-workflow]")?.dataset["checkWorkflow"];
+  if (check) {
+    void runWorkflowCheck(check);
+    return;
+  }
 
   const activate = target.closest<HTMLElement>("[data-activate]")?.dataset["activate"];
   if (activate) {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -115,7 +115,7 @@ type State = {
 };
 
 const POLL_MS = 2000;
-const PAGES = ["settings", "generate"] as const;
+const PAGES = ["workflows", "comfyui", "servers", "accepting", "generate"] as const;
 type Page = (typeof PAGES)[number];
 
 function el<T extends HTMLElement>(id: string): T {
@@ -288,10 +288,13 @@ function setNote(target: HTMLElement, text: string, isError = false): void {
 // Pages
 // ---------------------------------------------------------------------------
 
-/** Settings is the landing page; running a workflow by hand is the sideline. */
+/**
+ * Workflows is the landing tab; running a workflow by hand is the sideline.
+ * Any hash naming no tab lands there too — the old `#/settings` included.
+ */
 function currentPage(): Page {
   const hash = location.hash.replace(/^#\/?/, "");
-  return (PAGES as readonly string[]).includes(hash) ? (hash as Page) : "settings";
+  return (PAGES as readonly string[]).includes(hash) ? (hash as Page) : "workflows";
 }
 
 function showPage(): void {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -96,6 +96,12 @@ type State = {
   upstreams: UpstreamView[];
   settings: { comfyDir: string; comfyCommand: string };
   mode: RunMode;
+  accepting: {
+    accepting: boolean;
+    blockedBy: "mode" | "paused" | "schedule" | null;
+    pausedUntil: number | null;
+    schedule: { enabled: boolean; from: string; to: string };
+  };
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
 };
@@ -141,7 +147,14 @@ const nodes = {
   modePanel: el("mode-panel"),
   modeDot: el("mode-dot"),
   modeLabel: el("mode-label"),
+  modeGate: el("mode-gate"),
   modeNote: el("mode-note"),
+  acceptPause: el("accept-pause"),
+  acceptPauseState: el("accept-pause-state"),
+  acceptEnabled: el<HTMLInputElement>("accept-enabled"),
+  acceptFrom: el<HTMLInputElement>("accept-from"),
+  acceptTo: el<HTMLInputElement>("accept-to"),
+  acceptNote: el("accept-note"),
   desktopAutostart: el<HTMLInputElement>("desktop-autostart"),
   desktopNote: el("desktop-note"),
 };
@@ -167,6 +180,11 @@ function formatDuration(ms: number): string {
 
 function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString(locale());
+}
+
+/** Whole minutes still to go. Never zero: seconds left is still time left. */
+function minutesLeft(until: number): number {
+  return Math.max(1, Math.ceil((until - Date.now()) / 60_000));
 }
 
 /**
@@ -291,6 +309,16 @@ function renderVitals(state: State): void {
   const healthy = agent.upstreams.filter((server) => server.heartbeat?.ok).length;
   const agentTone = healthy === total ? "ok" : healthy > 0 ? "warn" : "bad";
 
+  // What is holding jobs back beats the mode here: "accepting" with a pause
+  // running is not what anyone glancing at the bar wants to be told.
+  const gate = state.accepting;
+  const work =
+    gate.blockedBy === "paused" && gate.pausedUntil !== null
+      ? { label: t("accept.paused", { minutes: minutesLeft(gate.pausedUntil) }), tone: "idle" }
+      : gate.blockedBy === "schedule"
+        ? { label: t("accept.outside"), tone: "idle" }
+        : { label: modeLabel(state.mode), tone: MODE_TONE[state.mode] };
+
   const chips = [
     chip(t("vitals.comfy"), esc(comfyStatusLabel(comfy.comfyStatus)), tone),
     chip(t("vitals.running"), pad(comfy.queueRunning)),
@@ -298,7 +326,7 @@ function renderVitals(state: State): void {
     total === 0
       ? chip(t("vitals.agent"), t("vitals.standalone"))
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
-    chip(t("vitals.work"), modeLabel(state.mode), MODE_TONE[state.mode]),
+    chip(t("vitals.work"), work.label, work.tone),
   ];
 
   if (comfyProcess.managed) {
@@ -658,6 +686,59 @@ function syncMode(state: State): void {
   for (const option of document.querySelectorAll<HTMLElement>("[data-mode]")) {
     option.setAttribute("aria-pressed", String(option.dataset["mode"] === state.mode));
   }
+
+  const gate = state.accepting;
+  nodes.modeGate.textContent =
+    gate.blockedBy === "paused" && gate.pausedUntil !== null
+      ? t("accept.gatePaused", { minutes: minutesLeft(gate.pausedUntil) })
+      : gate.blockedBy === "schedule"
+        ? t("accept.gateSchedule", { from: gate.schedule.from, to: gate.schedule.to })
+        : "";
+}
+
+// ---------------------------------------------------------------------------
+// Accepting — when the mode is allowed to claim
+// ---------------------------------------------------------------------------
+
+/** Held while a control is in flight, so a poll cannot flip it back. */
+let acceptBusy = false;
+
+function syncAccepting(state: State): void {
+  const { pausedUntil, schedule } = state.accepting;
+
+  nodes.acceptPauseState.textContent =
+    pausedUntil === null
+      ? t("accept.notPaused")
+      : t("accept.pausedUntil", {
+          time: formatTime(pausedUntil),
+          minutes: minutesLeft(pausedUntil),
+        });
+
+  // Nothing to resume from when nothing is on hold.
+  for (const button of nodes.acceptPause.querySelectorAll<HTMLButtonElement>('[data-pause="0"]')) {
+    button.disabled = pausedUntil === null;
+  }
+
+  if (acceptBusy) return;
+  nodes.acceptEnabled.checked = schedule.enabled;
+  // A time is saved as soon as it changes, so the only field worth leaving
+  // alone is the one being typed into.
+  if (document.activeElement !== nodes.acceptFrom) nodes.acceptFrom.value = schedule.from;
+  if (document.activeElement !== nodes.acceptTo) nodes.acceptTo.value = schedule.to;
+}
+
+/** Send one change, then let the next poll confirm it. */
+async function saveAccepting(path: string, body: unknown): Promise<void> {
+  acceptBusy = true;
+  const result = await post(path, body);
+  acceptBusy = false;
+
+  setNote(
+    nodes.acceptNote,
+    result.ok ? t("accept.saved") : (result.error ?? t("accept.saveFailed")),
+    !result.ok,
+  );
+  void poll();
 }
 
 // ---------------------------------------------------------------------------
@@ -760,6 +841,7 @@ function render(state: State): void {
   renderJobs(state);
   syncSettings(state);
   syncMode(state);
+  syncAccepting(state);
   syncDesktop(state);
   syncForm(state);
 }
@@ -858,7 +940,13 @@ onLangChange(() => {
 
   // Notes report something that has already happened, so they are cleared
   // rather than translated after the fact.
-  for (const note of [nodes.note, nodes.uploadNote, nodes.settingsNote, nodes.serversNote]) {
+  for (const note of [
+    nodes.note,
+    nodes.uploadNote,
+    nodes.settingsNote,
+    nodes.serversNote,
+    nodes.acceptNote,
+  ]) {
     setNote(note, "");
   }
 
@@ -1142,6 +1230,29 @@ nodes.desktopPanel.addEventListener("click", (event) => {
   ];
   if (choice) void saveDesktop("/api/desktop", { closeAction: choice });
 });
+
+nodes.acceptPause.addEventListener("click", (event) => {
+  const minutes = (event.target as HTMLElement).closest<HTMLElement>("[data-pause]")?.dataset[
+    "pause"
+  ];
+  if (minutes === undefined) return;
+  void saveAccepting("/api/accept/pause", { minutes: Number(minutes) });
+});
+
+nodes.acceptEnabled.addEventListener("change", () => {
+  void saveAccepting("/api/accept/schedule", { enabled: nodes.acceptEnabled.checked });
+});
+
+// Both go together: a window is the pair, and sending one of them alone would
+// save a half-edited window on the way to the other field.
+for (const input of [nodes.acceptFrom, nodes.acceptTo]) {
+  input.addEventListener("change", () => {
+    void saveAccepting("/api/accept/schedule", {
+      from: nodes.acceptFrom.value,
+      to: nodes.acceptTo.value,
+    });
+  });
+}
 
 // Ticking elapsed time for running jobs, kept out of the render pass so it
 // never rewrites the job list.

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -134,6 +134,9 @@ const nodes = {
   workflowDir: el("workflow-dir"),
   servers: el("servers"),
   serversNote: el("servers-note"),
+  linkUrl: el<HTMLInputElement>("link-url"),
+  linkCode: el<HTMLInputElement>("link-code"),
+  linkNote: el("link-note"),
   jobs: el("jobs"),
   form: el<HTMLFormElement>("run-form"),
   select: el<HTMLSelectElement>("run-workflow"),
@@ -1165,6 +1168,33 @@ el("server-add").addEventListener("click", () => {
   ];
   serversDirty = true;
   if (latestState) renderServers(latestState);
+});
+
+/**
+ * The row is written on the server side, so what comes back is the truth and
+ * the editor is resynced onto it — including anything typed but not saved.
+ */
+el("server-link").addEventListener("click", async () => {
+  const url = nodes.linkUrl.value.trim();
+  const code = nodes.linkCode.value.trim();
+  if (!url || !code) {
+    setNote(nodes.linkNote, t("servers.linkNeeds"), true);
+    return;
+  }
+
+  setNote(nodes.linkNote, t("servers.linking"));
+  const result = await post<{ hostName: string | null }>("/api/link", { url, code });
+  if (!result.ok) {
+    setNote(nodes.linkNote, result.error ?? t("servers.linkFailed"), true);
+    return;
+  }
+
+  // Spent on use, so leaving it in the box would only invite a second try.
+  nodes.linkCode.value = "";
+  serversDirty = false;
+  const name = result.data?.hostName;
+  setNote(nodes.linkNote, name ? t("servers.linkedAs", { name }) : t("servers.linked"));
+  void poll();
 });
 
 nodes.servers.addEventListener("input", () => {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -7,7 +7,7 @@
  * into is left alone until they save or revert.
  */
 
-import { LANGS, lang, locale, onLangChange, setLang, t } from "./i18n";
+import { LANGS, isKey, lang, locale, onLangChange, setLang, t } from "./i18n";
 import type { Key, Lang } from "./i18n";
 
 type RunMode = "accepting" | "local" | "paused";
@@ -114,6 +114,8 @@ type State = {
   } | null;
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
+  /** Ring of recent server-side events, oldest first; ids only ever grow. */
+  events: { id: number; at: number; kind: string; params: Record<string, string> }[];
 };
 
 const POLL_MS = 2000;
@@ -170,6 +172,8 @@ const nodes = {
   acceptNote: el("accept-note"),
   desktopAutostart: el<HTMLInputElement>("desktop-autostart"),
   desktopNote: el("desktop-note"),
+  notifyEnabled: el<HTMLInputElement>("notify-enabled"),
+  notifyNote: el("notify-note"),
 };
 
 function esc(value: unknown): string {
@@ -776,7 +780,10 @@ function openPopover(target: Popover | null): void {
     popover.panel.hidden = !open;
     popover.button.setAttribute("aria-expanded", String(open));
   }
-  if (target !== DESKTOP_POPOVER) setNote(nodes.desktopNote, "");
+  if (target !== DESKTOP_POPOVER) {
+    setNote(nodes.desktopNote, "");
+    setNote(nodes.notifyNote, "");
+  }
   if (target !== MODE_POPOVER) setNote(nodes.modeNote, "");
 }
 
@@ -901,6 +908,111 @@ async function saveDesktop(path: string, body: unknown): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Notifications — server-side events turned into OS notifications
+// ---------------------------------------------------------------------------
+
+const NOTIFY_KEY = "notify";
+const NOTIFY_SEEN_KEY = "notify-seen";
+
+function notifyOn(): boolean {
+  try {
+    return localStorage.getItem(NOTIFY_KEY) === "on";
+  } catch {
+    return false;
+  }
+}
+
+function storeNotify(on: boolean): void {
+  try {
+    localStorage.setItem(NOTIFY_KEY, on ? "on" : "off");
+  } catch {
+    // Private mode — the choice lasts for this tab only.
+  }
+}
+
+let notifySeen = (() => {
+  try {
+    return Number(localStorage.getItem(NOTIFY_SEEN_KEY) ?? "0") || 0;
+  } catch {
+    return 0;
+  }
+})();
+
+/** False until the first poll: its backlog predates this page, so it is noise. */
+let notifyPrimed = false;
+
+function rememberSeen(id: number): void {
+  notifySeen = id;
+  try {
+    localStorage.setItem(NOTIFY_SEEN_KEY, String(id));
+  } catch {
+    // Private mode — an old event may notify again after a reload.
+  }
+}
+
+function notifyGranted(): boolean {
+  return "Notification" in window && Notification.permission === "granted";
+}
+
+function syncNotify(state: State): void {
+  const newest = state.events.at(-1)?.id ?? 0;
+
+  if (!notifyPrimed) {
+    notifyPrimed = true;
+    if (newest > notifySeen) rememberSeen(newest);
+    return;
+  }
+  if (newest <= notifySeen) return;
+
+  const fresh = state.events.filter((event) => event.id > notifySeen);
+  // Advanced even while notifications are off, so turning them on later does
+  // not replay history.
+  rememberSeen(newest);
+  if (!notifyOn() || !notifyGranted()) return;
+
+  for (const event of fresh) {
+    const key = `notify.${event.kind}`;
+    // A kind this page has no words for is skipped rather than crashed on —
+    // the server can be newer than a cached page.
+    if (!isKey(key)) continue;
+    try {
+      new Notification(t(key, event.params), {
+        body: event.params["error"] ?? "",
+        tag: `dcs-${event.id}`,
+      });
+    } catch {
+      // The permission can be revoked between polls; nothing to be done.
+    }
+  }
+}
+
+/**
+ * Turning it on asks the browser there and then, so the permission prompt is
+ * the answer to a click rather than appearing out of nowhere.
+ */
+async function setNotify(on: boolean): Promise<void> {
+  if (!on) {
+    storeNotify(false);
+    setNote(nodes.notifyNote, "");
+    return;
+  }
+  if (!("Notification" in window)) {
+    nodes.notifyEnabled.checked = false;
+    setNote(nodes.notifyNote, t("notify.unsupported"), true);
+    return;
+  }
+  const permission =
+    Notification.permission === "granted" ? "granted" : await Notification.requestPermission();
+  if (permission !== "granted") {
+    nodes.notifyEnabled.checked = false;
+    setNote(nodes.notifyNote, t("notify.blocked"), true);
+    return;
+  }
+  storeNotify(true);
+  setNote(nodes.notifyNote, "");
+}
+
+// ---------------------------------------------------------------------------
 // Run form
 // ---------------------------------------------------------------------------
 
@@ -970,6 +1082,7 @@ function render(state: State): void {
   syncMode(state);
   syncAccepting(state);
   syncDesktop(state);
+  syncNotify(state);
   syncForm(state);
 }
 
@@ -1385,6 +1498,8 @@ nodes.desktopAutostart.addEventListener("change", () => {
   void saveDesktop("/api/desktop", { autostart: nodes.desktopAutostart.checked });
 });
 
+nodes.notifyEnabled.addEventListener("change", () => void setNotify(nodes.notifyEnabled.checked));
+
 nodes.desktopPanel.addEventListener("click", (event) => {
   const choice = (event.target as HTMLElement).closest<HTMLElement>("[data-close-action]")?.dataset[
     "closeAction"
@@ -1423,6 +1538,9 @@ setInterval(() => {
     if (Number.isFinite(started)) span.textContent = formatDuration(Date.now() - started);
   }
 }, 1000);
+
+// A permission revoked since last time reads as "off", matching what happens.
+nodes.notifyEnabled.checked = notifyOn() && notifyGranted();
 
 applyTheme(currentTheme());
 setLang(lang());

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -51,6 +51,8 @@ type JobRecord = {
   promptId?: string;
   outputs?: RunOutput[];
   error?: string;
+  /** Tries this job has had on this machine; absent means the first. */
+  attempts?: number;
   interrupted?: boolean;
 };
 
@@ -735,6 +737,8 @@ function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress
     </div>
     <p class="meta">${formatTime(job.startedAt)} · ${timing}${origin}${
       job.promptId ? ` · ${t("jobs.prompt", { id: esc(job.promptId.slice(0, 8)) })}` : ""
+    }${
+      job.attempts && job.attempts > 1 ? ` · ${t("jobs.attempt", { count: job.attempts })}` : ""
     }</p>
     ${progressBar(job, progress)}
     ${jobError(job)}

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -760,12 +760,62 @@ function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress
   </div>`;
 }
 
+// Page-local: the history itself is what it is, only its reading is chosen.
+type JobStateFilter = "all" | JobRecord["state"];
+type JobSourceFilter = "all" | JobRecord["source"];
+type JobsView = "list" | "gallery";
+
+let jobStateFilter: JobStateFilter = "all";
+let jobSourceFilter: JobSourceFilter = "all";
+let jobsView: JobsView = "list";
+
+/**
+ * Every image and video the filtered runs produced, newest first, each cell
+ * opening (or playing) the file itself. Failures and files that are neither
+ * are the list view's business.
+ */
+function galleryHtml(jobs: JobRecord[]): string {
+  const cells: string[] = [];
+  for (const job of jobs) {
+    for (const output of job.outputs ?? []) {
+      const url = outputUrl(output);
+      const name = esc(output.filename);
+      const caption = `${esc(job.workflow)} · ${formatTime(job.startedAt)}`;
+      if (output.kind === "image") {
+        cells.push(
+          `<a class="cell" href="${url}" target="_blank" rel="noreferrer" title="${caption}">` +
+            `<img src="${url}" alt="${name}" loading="lazy" /></a>`,
+        );
+      } else if (output.kind === "video") {
+        cells.push(
+          `<div class="cell" title="${caption}">` +
+            `<video src="${url}" controls preload="metadata" title="${name}"></video></div>`,
+        );
+      }
+    }
+  }
+  if (cells.length === 0) return `<p class="empty">${t("jobs.noMedia")}</p>`;
+  return `<div class="gallery">${cells.join("")}</div>`;
+}
+
 function renderJobs(state: State): void {
-  if (state.jobs.length === 0) {
-    renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${t("jobs.empty")}</p>`);
+  const jobs = state.jobs.filter(
+    (job) =>
+      (jobStateFilter === "all" || job.state === jobStateFilter) &&
+      (jobSourceFilter === "all" || job.source === jobSourceFilter),
+  );
+
+  if (jobsView === "gallery") {
+    renderIfChanged(nodes.jobs, "jobs", galleryHtml(jobs));
     return;
   }
-  const html = state.jobs.map((job) => jobEntry(job, true, state.progress)).join("");
+  if (jobs.length === 0) {
+    // An empty history and a filter that matched nothing read differently.
+    const text = state.jobs.length === 0 ? t("jobs.empty") : t("jobs.noMatch");
+    renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${text}</p>`);
+    return;
+  }
+  const html = jobs.map((job) => jobEntry(job, true, state.progress)).join("");
   renderIfChanged(nodes.jobs, "jobs", `<div class="ledger">${html}</div>`);
 }
 
@@ -1492,6 +1542,44 @@ nodes.jobs.addEventListener("click", async (event) => {
   lastHtml.delete("jobs");
   void poll();
 });
+
+function syncJobFilterButtons(): void {
+  const groups: [attribute: string, current: string][] = [
+    ["data-job-state", jobStateFilter],
+    ["data-job-source", jobSourceFilter],
+    ["data-job-view", jobsView],
+  ];
+  for (const [attribute, current] of groups) {
+    for (const button of document.querySelectorAll<HTMLElement>(`[${attribute}]`)) {
+      button.setAttribute("aria-pressed", String(button.getAttribute(attribute) === current));
+    }
+  }
+}
+
+/** The three groups differ only in which variable a click sets. */
+function wireJobFilter(id: string, attribute: string, apply: (value: string) => void): void {
+  el(id).addEventListener("click", (event) => {
+    const value = (event.target as HTMLElement)
+      .closest<HTMLElement>(`[${attribute}]`)
+      ?.getAttribute(attribute);
+    if (!value) return;
+    apply(value);
+    syncJobFilterButtons();
+    if (latestState) renderJobs(latestState);
+  });
+}
+
+wireJobFilter("jobs-state", "data-job-state", (value) => {
+  jobStateFilter = value as JobStateFilter;
+});
+wireJobFilter("jobs-source", "data-job-source", (value) => {
+  jobSourceFilter = value as JobSourceFilter;
+});
+wireJobFilter("jobs-view", "data-job-view", (value) => {
+  jobsView = value as JobsView;
+});
+
+syncJobFilterButtons();
 
 nodes.settingsForm.addEventListener("input", () => {
   settingsDirty = true;

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -98,7 +98,9 @@ type State = {
     }[];
   };
   upstreams: UpstreamView[];
-  settings: { comfyDir: string; comfyCommand: string };
+  settings: { comfyDir: string; comfyCommand: string; outputCleanupDays: number };
+  /** ComfyUI's output folder as last scanned; null when there is none. */
+  outputs: { dir: string; files: number; bytes: number; scannedAt: number } | null;
   mode: RunMode;
   accepting: {
     accepting: boolean;
@@ -176,6 +178,12 @@ const nodes = {
   desktopNote: el("desktop-note"),
   notifyEnabled: el<HTMLInputElement>("notify-enabled"),
   notifyNote: el("notify-note"),
+  outputsDir: el("outputs-dir"),
+  outputsInfo: el("outputs-info"),
+  outputsDays: el<HTMLInputElement>("outputs-days"),
+  outputsAuto: el<HTMLInputElement>("outputs-auto"),
+  outputsTrim: el<HTMLButtonElement>("outputs-trim"),
+  outputsNote: el("outputs-note"),
 };
 
 function esc(value: unknown): string {
@@ -209,6 +217,12 @@ function progressPercent(progress: { value: number; max: number }): number {
 /** Bytes as gigabytes with one decimal, the unit VRAM is talked about in. */
 function gb(bytes: number): string {
   return (bytes / 1024 ** 3).toFixed(1);
+}
+
+/** "3.2 GB" or "410 MB", for sizes whose scale is not known in advance. */
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${gb(bytes)} GB`;
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -768,6 +782,59 @@ function syncSettings(state: State): void {
 }
 
 // ---------------------------------------------------------------------------
+// Outputs — ComfyUI's output folder
+// ---------------------------------------------------------------------------
+
+function syncOutputs(state: State): void {
+  if (!state.outputs) {
+    nodes.outputsDir.textContent = "";
+    nodes.outputsInfo.textContent = t("outputs.none");
+    nodes.outputsTrim.disabled = true;
+  } else {
+    nodes.outputsDir.textContent = state.outputs.dir;
+    nodes.outputsInfo.textContent = t("outputs.count", {
+      files: state.outputs.files,
+      size: formatBytes(state.outputs.bytes),
+    });
+    nodes.outputsTrim.disabled = false;
+  }
+
+  // Like the schedule times: only the field being typed into is left alone.
+  if (document.activeElement !== nodes.outputsAuto) {
+    nodes.outputsAuto.value = String(state.settings.outputCleanupDays);
+  }
+}
+
+async function trimOutputsNow(): Promise<void> {
+  const days = Number(nodes.outputsDays.value);
+  if (!Number.isFinite(days) || days < 1) {
+    setNote(nodes.outputsNote, t("outputs.needDays"), true);
+    return;
+  }
+  if (!confirm(t("outputs.confirm", { days }))) return;
+
+  nodes.outputsTrim.disabled = true;
+  setNote(nodes.outputsNote, t("outputs.trimming"));
+  const result = await post<{ removedFiles: number; removedBytes: number }>("/api/outputs/trim", {
+    days,
+  });
+  nodes.outputsTrim.disabled = false;
+
+  if (!result.ok) {
+    setNote(nodes.outputsNote, result.error ?? t("outputs.trimFailed"), true);
+    return;
+  }
+  setNote(
+    nodes.outputsNote,
+    t("outputs.trimmed", {
+      files: result.data?.removedFiles ?? 0,
+      size: formatBytes(result.data?.removedBytes ?? 0),
+    }),
+  );
+  void poll();
+}
+
+// ---------------------------------------------------------------------------
 // Header menus
 // ---------------------------------------------------------------------------
 
@@ -1083,6 +1150,7 @@ function render(state: State): void {
   syncServers(state);
   renderJobs(state);
   syncSettings(state);
+  syncOutputs(state);
   syncMode(state);
   syncAccepting(state);
   syncDesktop(state);
@@ -1459,6 +1527,22 @@ async function toggleComfy(): Promise<void> {
 
 nodes.comfyPower.addEventListener("click", () => void toggleComfy());
 nodes.comfyPower2.addEventListener("click", () => void toggleComfy());
+
+nodes.outputsTrim.addEventListener("click", () => void trimOutputsNow());
+
+// Saved on change like the schedule: one number is not worth a Save button.
+nodes.outputsAuto.addEventListener("change", async () => {
+  const days = Number(nodes.outputsAuto.value);
+  const result = await post("/api/settings", {
+    outputCleanupDays: Number.isFinite(days) ? days : 0,
+  });
+  setNote(
+    nodes.outputsNote,
+    result.ok ? t("outputs.saved") : (result.error ?? t("comfy.saveFailed")),
+    !result.ok,
+  );
+  void poll();
+});
 
 nodes.desktopOpen.addEventListener("click", () => toggle(DESKTOP_POPOVER));
 nodes.modeOpen.addEventListener("click", () => toggle(MODE_POPOVER));

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -102,6 +102,14 @@ type State = {
     pausedUntil: number | null;
     schedule: { enabled: boolean; from: string; to: string };
   };
+  /** How far the run in flight has got, or null when nothing is reporting. */
+  progress: {
+    promptId: string;
+    value: number;
+    max: number;
+    node: string | null;
+    at: number;
+  } | null;
   desktop: { autostart: boolean; closeAction: "tray" | "quit" };
   jobs: JobRecord[];
 };
@@ -180,6 +188,11 @@ function formatDuration(ms: number): string {
 
 function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString(locale());
+}
+
+/** Whole percent, clamped — a step past the max would otherwise overflow the bar. */
+function progressPercent(progress: { value: number; max: number }): number {
+  return Math.min(100, Math.max(0, Math.round((progress.value / progress.max) * 100)));
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -333,6 +346,10 @@ function renderVitals(state: State): void {
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
     chip(t("vitals.work"), work.label, work.tone),
   ];
+
+  if (state.progress && state.progress.max > 0) {
+    chips.push(chip(t("vitals.progress"), `${progressPercent(state.progress)}%`, "run"));
+  }
 
   if (comfyProcess.managed) {
     chips.push(chip(t("vitals.process"), `pid ${comfyProcess.pid ?? "?"}`, "run"));
@@ -643,7 +660,25 @@ function jobError(job: JobRecord): string {
   return job.error ? `<p class="error">${esc(job.error)}</p>` : "";
 }
 
-function jobEntry(job: JobRecord, withDelete: boolean): string {
+/**
+ * The bar under a running row, and nothing at all otherwise. Matched by prompt
+ * id: ComfyUI reports on the prompt it is executing, which is only this job when
+ * the two ids agree — anything else on that queue is not ours to draw.
+ */
+function progressBar(job: JobRecord, progress: State["progress"]): string {
+  if (job.state !== "running" || !progress || progress.max <= 0) return "";
+  if (!progress.promptId || progress.promptId !== job.promptId) return "";
+
+  const percent = progressPercent(progress);
+  return `<div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${percent}">
+      <span style="width: ${percent}%"></span>
+    </div>
+    <p class="meta">${t("jobs.progress", { percent, value: progress.value, max: progress.max })}${
+      progress.node ? ` · ${t("jobs.node", { node: esc(progress.node) })}` : ""
+    }</p>`;
+}
+
+function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress"]): string {
   const tone = job.state === "running" ? "run" : job.state === "succeeded" ? "ok" : "bad";
   const origin =
     job.source === "upstream"
@@ -668,6 +703,7 @@ function jobEntry(job: JobRecord, withDelete: boolean): string {
     <p class="meta">${formatTime(job.startedAt)} · ${timing}${origin}${
       job.promptId ? ` · ${t("jobs.prompt", { id: esc(job.promptId.slice(0, 8)) })}` : ""
     }</p>
+    ${progressBar(job, progress)}
     ${jobError(job)}
     ${job.outputs?.length ? renderOutputs(job.outputs) : ""}
   </div>`;
@@ -678,7 +714,7 @@ function renderJobs(state: State): void {
     renderIfChanged(nodes.jobs, "jobs", `<p class="empty">${t("jobs.empty")}</p>`);
     return;
   }
-  const html = state.jobs.map((job) => jobEntry(job, true)).join("");
+  const html = state.jobs.map((job) => jobEntry(job, true, state.progress)).join("");
   renderIfChanged(nodes.jobs, "jobs", `<div class="ledger">${html}</div>`);
 }
 

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -69,6 +69,8 @@ type State = {
     comfyStatus: "available" | "busy" | "unavailable";
     queueRunning: number;
     queuePending: number;
+    /** VRAM in bytes, as ComfyUI reports its GPU; null without one. */
+    gpu: { name: string; vramTotal: number; vramFree: number } | null;
     checkedAt: number;
   };
   comfyProcess: {
@@ -196,6 +198,11 @@ function formatTime(ms: number): string {
 /** Whole percent, clamped — a step past the max would otherwise overflow the bar. */
 function progressPercent(progress: { value: number; max: number }): number {
   return Math.min(100, Math.max(0, Math.round((progress.value / progress.max) * 100)));
+}
+
+/** Bytes as gigabytes with one decimal, the unit VRAM is talked about in. */
+function gb(bytes: number): string {
+  return (bytes / 1024 ** 3).toFixed(1);
 }
 
 /** Whole minutes still to go. Never zero: seconds left is still time left. */
@@ -347,11 +354,27 @@ function renderVitals(state: State): void {
     chip(t("vitals.comfy"), esc(comfyStatusLabel(comfy.comfyStatus)), tone),
     chip(t("vitals.running"), pad(comfy.queueRunning)),
     chip(t("vitals.pending"), pad(comfy.queuePending)),
+  ];
+
+  // The GPU is what this machine lends out, so its headroom belongs up here.
+  // The dot only appears when the free VRAM is running out.
+  if (comfy.gpu) {
+    const low = comfy.gpu.vramFree / comfy.gpu.vramTotal < 0.1;
+    chips.push(
+      chip(
+        t("vitals.vram"),
+        `${gb(comfy.gpu.vramTotal - comfy.gpu.vramFree)}/${gb(comfy.gpu.vramTotal)} GB`,
+        low ? "warn" : undefined,
+      ),
+    );
+  }
+
+  chips.push(
     total === 0
       ? chip(t("vitals.agent"), t("vitals.standalone"))
       : chip(t("vitals.agent"), `${pad(healthy)}/${pad(total)}`, agentTone),
     chip(t("vitals.work"), work.label, work.tone),
-  ];
+  );
 
   if (state.progress && state.progress.max > 0) {
     chips.push(chip(t("vitals.progress"), `${progressPercent(state.progress)}%`, "run"));

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -229,7 +229,10 @@ function outputUrl(output: RunOutput): string {
   return `/api/output?${query}`;
 }
 
-async function post(path: string, body?: unknown): Promise<{ ok: boolean; error?: string }> {
+async function post<T = unknown>(
+  path: string,
+  body?: unknown,
+): Promise<{ ok: boolean; error?: string; data?: T }> {
   try {
     const res = await fetch(path, {
       method: "POST",
@@ -239,8 +242,10 @@ async function post(path: string, body?: unknown): Promise<{ ok: boolean; error?
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
     });
-    const parsed = (await res.json().catch(() => ({}))) as { error?: string };
-    return res.ok ? { ok: true } : { ok: false, error: parsed.error ?? `HTTP ${res.status}` };
+    const parsed = (await res.json().catch(() => ({}))) as { error?: string } & T;
+    return res.ok
+      ? { ok: true, data: parsed }
+      : { ok: false, error: parsed.error ?? `HTTP ${res.status}` };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
@@ -444,7 +449,14 @@ function renderWorkflows(state: State): void {
 // Upstream servers — an editor, so polling must not overwrite what is typed
 // ---------------------------------------------------------------------------
 
-type ServerRow = UpstreamView & { secret: string };
+type UpstreamTest = { ok: boolean; ms: number; pendingJobs?: number; error?: string };
+
+/**
+ * A row as it stands on screen: the stored server, the secret box (blank means
+ * "keep the stored one"), and the last test of it. `testing` is held on the row
+ * rather than globally so testing one server leaves the others alone.
+ */
+type ServerRow = UpstreamView & { secret: string; testing?: boolean; test?: UpstreamTest };
 
 let serverRows: ServerRow[] | null = null;
 let serversDirty = false;
@@ -459,6 +471,23 @@ function heartbeatFor(state: State, row: ServerRow): string {
   return `<span class="state"><span class="dot ${beat.ok ? "ok" : "bad"}"></span>${
     beat.ok ? t("servers.up") : t("servers.down")
   }${waiting}</span>`;
+}
+
+/** The last test of this row, in its own words. Nothing until one is run. */
+function testResultFor(row: ServerRow): string {
+  if (row.testing) return `<p class="meta">${t("servers.testing")}</p>`;
+  if (!row.test) return "";
+
+  if (!row.test.ok) {
+    return `<p class="error">${t("servers.testFailed", {
+      error: esc(row.test.error ?? ""),
+    })}</p>`;
+  }
+  const queued =
+    row.test.pendingJobs === undefined
+      ? ""
+      : ` · ${t("servers.queued", { count: row.test.pendingJobs })}`;
+  return `<p class="meta">${t("servers.testOk", { ms: row.test.ms })}${queued}</p>`;
 }
 
 function renderServers(state: State): void {
@@ -477,6 +506,9 @@ function renderServers(state: State): void {
           <span class="mono muted">${pad(index + 1)}</span>
           ${heartbeatFor(state, row)}
           <span class="spacer"></span>
+          <button type="button" class="ghost" data-test-server="${index}">${t(
+            "servers.test",
+          )}</button>
           <button type="button" class="ghost" data-move="${index}" data-dir="-1" ${
             index === 0 ? "disabled" : ""
           } title="${t("servers.higher")}">↑</button>
@@ -515,9 +547,39 @@ function renderServers(state: State): void {
           <input type="checkbox" data-field="enabled" ${row.enabled ? "checked" : ""} />
           <span>${t("servers.enabled")}</span>
         </label>
+        ${testResultFor(row)}
       </div>`,
     )
     .join("")}</div>`;
+}
+
+/**
+ * Ask one server for a heartbeat now and keep the answer on its row. What is on
+ * screen is sent, so a secret typed a moment ago is what gets tried.
+ */
+async function testServer(index: number): Promise<void> {
+  const row = serverRows?.[index];
+  if (!row || !latestState) return;
+
+  row.testing = true;
+  row.test = undefined;
+  renderServers(latestState);
+
+  const result = await post<UpstreamTest>("/api/upstreams/test", {
+    id: row.id || undefined,
+    url: row.url,
+    hostId: row.hostId,
+    // Blank means the stored one, exactly as saving reads it.
+    secret: row.secret,
+  });
+
+  row.testing = false;
+  // A request the server refused outright — a row with no URL yet — is the same
+  // kind of answer as one it sent: it belongs on the row, not in the console.
+  row.test = result.ok
+    ? (result.data ?? { ok: true, ms: 0 })
+    : { ok: false, ms: 0, error: result.error ?? "" };
+  if (latestState) renderServers(latestState);
 }
 
 /** Copy what is on screen back into the model before any structural change. */
@@ -1087,6 +1149,13 @@ nodes.servers.addEventListener("click", (event) => {
       serversDirty = true;
       if (latestState) renderServers(latestState);
     }
+    return;
+  }
+
+  const test = target.closest<HTMLElement>("[data-test-server]");
+  if (test && serverRows) {
+    readServerInputs();
+    void testServer(Number(test.dataset["testServer"]));
     return;
   }
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -223,6 +223,20 @@ const STRINGS = {
   },
   "jobs.node": { en: "node {node}", ja: "ノード {node}" },
   "jobs.attempt": { en: "attempt {count}", ja: "試行 {count} 回目" },
+  "jobs.all": { en: "All", ja: "すべて" },
+  "jobs.filterState": { en: "State", ja: "状態" },
+  "jobs.filterSource": { en: "Source", ja: "発生元" },
+  "jobs.filterView": { en: "View", ja: "表示" },
+  "jobs.listView": { en: "List", ja: "リスト" },
+  "jobs.galleryView": { en: "Gallery", ja: "ギャラリー" },
+  "jobs.noMatch": {
+    en: "Nothing in the history matches the filter.",
+    ja: "条件に合う履歴はありません。",
+  },
+  "jobs.noMedia": {
+    en: "No images or videos in the filtered runs yet.",
+    ja: "条件に合う画像・動画はまだありません。",
+  },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -144,6 +144,10 @@ const STRINGS = {
     en: "ComfyUI keeps crashing — gave up restarting",
     ja: "ComfyUI がクラッシュを繰り返すため、再起動を諦めました",
   },
+  "notify.outputs-trimmed": {
+    en: "Old outputs deleted: {files} files ({size})",
+    ja: "古い出力を削除しました: {files} ファイル（{size}）",
+  },
 
   "nav.label": { en: "Sections", ja: "セクション" },
   "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
@@ -289,6 +293,32 @@ const STRINGS = {
   },
   "process.startedAt": { en: "started {time} · pid {pid}", ja: "{time} に起動 · pid {pid}" },
   "process.foreign": { en: "not started from here", ja: "ここからは起動していません" },
+
+  // ComfyUI's output folder --------------------------------------------------
+  "outputs.title": { en: "Outputs", ja: "出力ファイル" },
+  "outputs.none": {
+    en: "No output folder under the ComfyUI directory yet.",
+    ja: "ComfyUI ディレクトリの下に output フォルダがまだありません。",
+  },
+  "outputs.count": { en: "{files} files · {size}", ja: "{files} ファイル · {size}" },
+  "outputs.olderThan": { en: "Older than (days)", ja: "何日より古いか" },
+  "outputs.auto": {
+    en: "Auto-delete after (days, 0 = off)",
+    ja: "自動削除する日数（0 = オフ）",
+  },
+  "outputs.trim": { en: "Delete old outputs", ja: "古い出力を削除" },
+  "outputs.confirm": {
+    en: "Delete outputs older than {days} days? The files are removed from disk.",
+    ja: "{days} 日より古い出力を削除しますか？ディスクからファイルが消えます。",
+  },
+  "outputs.needDays": { en: "enter how many days", ja: "日数を入力してください" },
+  "outputs.trimming": { en: "deleting…", ja: "削除中…" },
+  "outputs.trimFailed": { en: "delete failed", ja: "削除できませんでした" },
+  "outputs.trimmed": {
+    en: "removed {files} files ({size})",
+    ja: "{files} ファイル（{size}）を削除しました",
+  },
+  "outputs.saved": { en: "saved", ja: "保存しました" },
 
   // Upstream servers --------------------------------------------------------
   "servers.title": { en: "Upstream servers", ja: "上流サーバー" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -268,6 +268,13 @@ const STRINGS = {
   },
   "workflows.deleteFailed": { en: "delete failed", ja: "削除できませんでした" },
   "workflows.nodes": { en: "{count} nodes", ja: "ノード {count} 個" },
+  "workflows.check": { en: "Check", ja: "チェック" },
+  "workflows.checking": { en: "checking against ComfyUI…", ja: "ComfyUI と照合中…" },
+  "workflows.checkOk": {
+    en: "every node and choice is available on this ComfyUI",
+    ja: "ノードもモデルも、この ComfyUI にすべて揃っています",
+  },
+  "workflows.checkFailed": { en: "check failed", ja: "チェックできませんでした" },
 
   "slot.detected": { en: "detected", ja: "自動検出" },
   "slot.override": { en: "from .slots.json", ja: ".slots.json での指定" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -116,6 +116,35 @@ const STRINGS = {
   "desktop.saved": { en: "saved", ja: "保存しました" },
   "desktop.saveFailed": { en: "save failed", ja: "保存できませんでした" },
 
+  // Notifications — the sentence for each event kind the server records ------
+  "notify.label": { en: "Notifications", ja: "通知" },
+  "notify.enable": { en: "Notify about failures", ja: "失敗や切断を通知する" },
+  "notify.unsupported": {
+    en: "this browser cannot show notifications",
+    ja: "このブラウザは通知に対応していません",
+  },
+  "notify.blocked": {
+    en: "the browser refused — allow notifications for this site",
+    ja: "ブラウザに拒否されました。このサイトの通知を許可してください",
+  },
+  "notify.job-failed": { en: "Job failed: {workflow}", ja: "ジョブ失敗: {workflow}" },
+  "notify.upstream-down": {
+    en: "Job server not answering: {server}",
+    ja: "ジョブサーバー応答なし: {server}",
+  },
+  "notify.upstream-up": {
+    en: "Job server back: {server}",
+    ja: "ジョブサーバー復帰: {server}",
+  },
+  "notify.comfy-crashed": {
+    en: "ComfyUI crashed — restarting it",
+    ja: "ComfyUI がクラッシュしました。再起動します",
+  },
+  "notify.comfy-gave-up": {
+    en: "ComfyUI keeps crashing — gave up restarting",
+    ja: "ComfyUI がクラッシュを繰り返すため、再起動を諦めました",
+  },
+
   "nav.label": { en: "Sections", ja: "セクション" },
   "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
   "nav.comfyui": { en: "ComfyUI", ja: "ComfyUI" },
@@ -332,6 +361,11 @@ const STRINGS = {
 } satisfies Record<string, Entry>;
 
 export type Key = keyof typeof STRINGS;
+
+/** Whether the table has words for `value` — for keys built at runtime. */
+export function isKey(value: string): value is Key {
+  return value in STRINGS;
+}
 
 const DEFAULT_LANG: Lang = LANGS[0].code;
 const STORAGE_KEY = "lang";

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -287,6 +287,10 @@ const STRINGS = {
   "servers.up": { en: "up", ja: "応答あり" },
   "servers.down": { en: "down", ja: "応答なし" },
   "servers.queued": { en: "{count} waiting", ja: "待ち {count} 件" },
+  "servers.test": { en: "Test", ja: "接続テスト" },
+  "servers.testing": { en: "testing…", ja: "テスト中…" },
+  "servers.testOk": { en: "answered in {ms} ms", ja: "{ms} ms で応答しました" },
+  "servers.testFailed": { en: "no answer — {error}", ja: "応答なし — {error}" },
 
   // Durations ---------------------------------------------------------------
   "time.seconds": { en: "{seconds}s", ja: "{seconds}秒" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -263,6 +263,27 @@ const STRINGS = {
     en: "Asked for work from the top down. The first server with something queued gets this machine, so the order is the priority.",
     ja: "上から順に問い合わせます。仕事を持っていた最初のサーバーがこのマシンを使うので、並び順がそのまま優先順位です。",
   },
+  "servers.link": { en: "Link", ja: "リンク" },
+  "servers.linkHelp": {
+    en: "Have a job server issue a link code, then paste it here with that server's URL. The code carries the credentials across, so there is nothing to copy by hand. Linking a server already in the list replaces its credentials.",
+    ja: "ジョブサーバー側でリンクコードを発行し、そのサーバーの URL と一緒に貼り付けてください。認証情報はコードが運ぶので、手で写すものはありません。すでに一覧にあるサーバーをリンクすると、その認証情報を置き換えます。",
+  },
+  "servers.linkUrl": { en: "Server URL", ja: "サーバー URL" },
+  "servers.linkCode": { en: "Link code", ja: "リンクコード" },
+  "servers.linkNeeds": {
+    en: "a URL and a code are both needed",
+    ja: "URL とコードの両方が必要です",
+  },
+  "servers.linking": { en: "linking…", ja: "リンク中…" },
+  "servers.linked": {
+    en: "linked — the agent picked it up",
+    ja: "リンクしました。エージェントに反映済みです",
+  },
+  "servers.linkedAs": {
+    en: "linked as {name} — the agent picked it up",
+    ja: "{name} としてリンクしました。エージェントに反映済みです",
+  },
+  "servers.linkFailed": { en: "linking failed", ja: "リンクできませんでした" },
   "servers.empty": {
     en: "No upstream servers. This machine runs whatever you queue here and nothing else.",
     ja: "上流サーバーはありません。このマシンはここで入れた分だけを実行します。",

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -63,6 +63,46 @@ const STRINGS = {
   },
   "mode.saveFailed": { en: "could not change it", ja: "変更できませんでした" },
 
+  // When jobs are accepted, on top of the mode -------------------------------
+  "accept.title": { en: "Accepting jobs", ja: "ジョブの受付" },
+  "accept.help": {
+    en: "When job servers get work out of this machine. Runs you start here, and ComfyUI itself, are not affected.",
+    ja: "ジョブサーバーからの仕事をいつ受けるかの設定です。ここから始める実行と ComfyUI 自体には影響しません。",
+  },
+  "accept.pauseFor": { en: "Hold off for", ja: "一時停止" },
+  "accept.pause15": { en: "15 min", ja: "15分" },
+  "accept.pause30": { en: "30 min", ja: "30分" },
+  "accept.pause60": { en: "1 hour", ja: "1時間" },
+  "accept.resume": { en: "Resume now", ja: "すぐ再開" },
+  "accept.pausedUntil": {
+    en: "On hold until {time}, {minutes} min left.",
+    ja: "{time} まで停止中です。あと {minutes} 分。",
+  },
+  "accept.notPaused": { en: "Not on hold.", ja: "一時停止していません。" },
+  "accept.schedule": { en: "Every day", ja: "毎日" },
+  "accept.scheduleOn": {
+    en: "Only accept between these times",
+    ja: "この時間帯だけ受け付ける",
+  },
+  "accept.from": { en: "From", ja: "開始" },
+  "accept.to": { en: "To", ja: "終了" },
+  "accept.overnight": {
+    en: "An end before the start runs overnight — 22:00 to 06:00 is tonight until tomorrow morning.",
+    ja: "終了が開始より前なら日をまたぎます。22:00〜06:00 は今夜から翌朝までです。",
+  },
+  "accept.saved": { en: "saved", ja: "保存しました" },
+  "accept.saveFailed": { en: "could not save it", ja: "保存できませんでした" },
+  "accept.paused": { en: "on hold {minutes}m", ja: "停止中 あと{minutes}分" },
+  "accept.outside": { en: "outside the window", ja: "時間帯外" },
+  "accept.gatePaused": {
+    en: "Jobs are on hold for another {minutes} min. Runs started here still go.",
+    ja: "あと {minutes} 分はジョブを受けません。ここからの実行は動きます。",
+  },
+  "accept.gateSchedule": {
+    en: "Outside {from}–{to}, so nothing is claimed. Runs started here still go.",
+    ja: "{from}〜{to} の外なのでジョブは受けません。ここからの実行は動きます。",
+  },
+
   // The desktop menu, mirrored by the tray -----------------------------------
   "desktop.title": { en: "Desktop app", ja: "デスクトップアプリ" },
   "desktop.autostart": { en: "Start when the computer starts", ja: "PC 起動時に起動する" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -129,6 +129,7 @@ const STRINGS = {
   "vitals.process": { en: "process", ja: "プロセス" },
   "vitals.access": { en: "access", ja: "アクセス" },
   "vitals.work": { en: "work", ja: "受付" },
+  "vitals.progress": { en: "progress", ja: "進捗" },
   "vitals.tokenNeeded": {
     en: "open this page as ?token=<UI_TOKEN>",
     ja: "?token=<UI_TOKEN> を付けて開いてください",
@@ -179,6 +180,11 @@ const STRINGS = {
   "jobs.ui": { en: "UI", ja: "UI" },
   "jobs.upstream": { en: "upstream", ja: "上流" },
   "jobs.prompt": { en: "prompt {id}", ja: "prompt {id}" },
+  "jobs.progress": {
+    en: "{percent}% · step {value}/{max}",
+    ja: "{percent}% · {value}/{max} ステップ",
+  },
+  "jobs.node": { en: "node {node}", ja: "ノード {node}" },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -132,6 +132,7 @@ const STRINGS = {
   "vitals.process": { en: "process", ja: "プロセス" },
   "vitals.access": { en: "access", ja: "アクセス" },
   "vitals.work": { en: "work", ja: "受付" },
+  "vitals.vram": { en: "VRAM", ja: "VRAM" },
   "vitals.progress": { en: "progress", ja: "進捗" },
   "vitals.tokenNeeded": {
     en: "open this page as ?token=<UI_TOKEN>",

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -117,7 +117,10 @@ const STRINGS = {
   "desktop.saveFailed": { en: "save failed", ja: "保存できませんでした" },
 
   "nav.label": { en: "Sections", ja: "セクション" },
-  "nav.settings": { en: "Settings", ja: "設定" },
+  "nav.workflows": { en: "Workflows", ja: "ワークフロー" },
+  "nav.comfyui": { en: "ComfyUI", ja: "ComfyUI" },
+  "nav.servers": { en: "Servers", ja: "サーバー" },
+  "nav.accepting": { en: "Accepting", ja: "ジョブ受付" },
   "nav.generate": { en: "Generate", ja: "生成" },
 
   // Status chips ------------------------------------------------------------
@@ -241,8 +244,8 @@ const STRINGS = {
   "comfy.start": { en: "Start ComfyUI", ja: "ComfyUI を起動" },
   "comfy.stop": { en: "Stop ComfyUI", ja: "ComfyUI を停止" },
   "comfy.needsDir": {
-    en: "set the ComfyUI directory on the Settings page first",
-    ja: "先に設定ページで ComfyUI のディレクトリを指定してください",
+    en: "set the ComfyUI directory on the ComfyUI page first",
+    ja: "先に ComfyUI ページでディレクトリを指定してください",
   },
 
   "process.title": { en: "Process", ja: "プロセス" },

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -218,6 +218,7 @@ const STRINGS = {
     ja: "{percent}% · {value}/{max} ステップ",
   },
   "jobs.node": { en: "node {node}", ja: "ノード {node}" },
+  "jobs.attempt": { en: "attempt {count}", ja: "試行 {count} 回目" },
   "jobs.interrupted": { en: "interrupted by a restart", ja: "再起動で中断されました" },
   "jobs.delete": { en: "Delete", ja: "削除" },
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -339,6 +339,87 @@
                   Clear finished
                 </button>
               </div>
+
+              <!-- Narrowing and reshaping only — the history itself is what it
+                   is. The choices live in the page, not on the server. -->
+              <div class="filters">
+                <div
+                  class="segmented text"
+                  id="jobs-state"
+                  role="group"
+                  data-i18n-label="jobs.filterState"
+                >
+                  <button type="button" data-job-state="all" data-i18n="jobs.all">All</button>
+                  <button type="button" data-job-state="running" data-i18n="jobs.running">
+                    running
+                  </button>
+                  <button type="button" data-job-state="succeeded" data-i18n="jobs.succeeded">
+                    succeeded
+                  </button>
+                  <button type="button" data-job-state="failed" data-i18n="jobs.failed">
+                    failed
+                  </button>
+                </div>
+                <div
+                  class="segmented text"
+                  id="jobs-source"
+                  role="group"
+                  data-i18n-label="jobs.filterSource"
+                >
+                  <button type="button" data-job-source="all" data-i18n="jobs.all">All</button>
+                  <button type="button" data-job-source="ui" data-i18n="jobs.ui">UI</button>
+                  <button type="button" data-job-source="upstream" data-i18n="jobs.upstream">
+                    upstream
+                  </button>
+                </div>
+                <div
+                  class="segmented"
+                  id="jobs-view"
+                  role="group"
+                  data-i18n-label="jobs.filterView"
+                >
+                  <button
+                    type="button"
+                    data-job-view="list"
+                    data-i18n-title="jobs.listView"
+                    aria-pressed="true"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                    <span class="sr-only" data-i18n="jobs.listView">List</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-job-view="gallery"
+                    data-i18n-title="jobs.galleryView"
+                    aria-pressed="false"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      aria-hidden="true"
+                    >
+                      <rect x="4" y="4" width="7" height="7" rx="1" />
+                      <rect x="13" y="4" width="7" height="7" rx="1" />
+                      <rect x="4" y="13" width="7" height="7" rx="1" />
+                      <rect x="13" y="13" width="7" height="7" rx="1" />
+                    </svg>
+                    <span class="sr-only" data-i18n="jobs.galleryView">Gallery</span>
+                  </button>
+                </div>
+              </div>
+
               <div id="jobs"></div>
             </section>
           </div>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -415,6 +415,30 @@
             </div>
             <div id="comfy-process"></div>
           </section>
+
+          <!-- What ComfyUI's output folder holds. Nothing in ComfyUI ever
+               deletes an output, so the disk fills quietly without this. -->
+          <section class="panel">
+            <div class="panel-head"><h2 data-i18n="outputs.title">Outputs</h2></div>
+            <p class="mono muted" id="outputs-dir"></p>
+            <p class="muted" id="outputs-info"></p>
+            <div class="row">
+              <label class="field">
+                <span data-i18n="outputs.olderThan">Older than (days)</span>
+                <input type="number" id="outputs-days" min="1" value="30" />
+              </label>
+              <label class="field">
+                <span data-i18n="outputs.auto">Auto-delete after (days, 0 = off)</span>
+                <input type="number" id="outputs-auto" min="0" />
+              </label>
+            </div>
+            <div class="actions">
+              <button type="button" class="ghost danger" id="outputs-trim" data-i18n="outputs.trim">
+                Delete old outputs
+              </button>
+              <p class="muted" id="outputs-note"></p>
+            </div>
+          </section>
         </section>
 
         <section class="page" data-page="servers" hidden>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -152,6 +152,13 @@
               <button type="button" data-close-action="quit" data-i18n="desktop.quit">Quits</button>
             </div>
 
+            <p class="popover-label" data-i18n="notify.label">Notifications</p>
+            <label class="switch">
+              <input type="checkbox" id="notify-enabled" />
+              <span data-i18n="notify.enable">Notify about failures</span>
+            </label>
+            <p class="muted" id="notify-note"></p>
+
             <p class="muted" data-i18n="desktop.note"></p>
             <p class="muted" id="desktop-note"></p>
           </div>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -234,10 +234,20 @@
     <div class="statusbar" id="vitals"></div>
 
     <div class="shell">
-      <!-- Navigation only. Actions and settings live on the pages themselves. -->
+      <!-- Navigation only. Actions and settings live on the pages themselves.
+           One tab per subject, so a page fits on screen instead of scrolling. -->
       <nav class="sidebar" data-i18n-label="nav.label">
-        <a class="nav-item" href="#/settings" data-page-link="settings" data-i18n="nav.settings"
-          >Settings</a
+        <a class="nav-item" href="#/workflows" data-page-link="workflows" data-i18n="nav.workflows"
+          >Workflows</a
+        >
+        <a class="nav-item" href="#/comfyui" data-page-link="comfyui" data-i18n="nav.comfyui"
+          >ComfyUI</a
+        >
+        <a class="nav-item" href="#/servers" data-page-link="servers" data-i18n="nav.servers"
+          >Servers</a
+        >
+        <a class="nav-item" href="#/accepting" data-page-link="accepting" data-i18n="nav.accepting"
+          >Accepting</a
         >
         <a class="nav-item" href="#/generate" data-page-link="generate" data-i18n="nav.generate"
           >Generate</a
@@ -327,7 +337,7 @@
           </div>
         </section>
 
-        <section class="page" data-page="settings">
+        <section class="page" data-page="workflows">
           <section class="panel">
             <div class="panel-head">
               <h2 data-i18n="upload.title">Upload</h2>
@@ -365,7 +375,9 @@
             <div class="panel-head"><h2 data-i18n="workflows.title">Installed</h2></div>
             <div id="workflows"></div>
           </section>
+        </section>
 
+        <section class="page" data-page="comfyui" hidden>
           <section class="panel">
             <div class="panel-head"><h2 data-i18n="comfy.title">ComfyUI</h2></div>
             <form id="settings-form">
@@ -396,7 +408,9 @@
             </div>
             <div id="comfy-process"></div>
           </section>
+        </section>
 
+        <section class="page" data-page="servers" hidden>
           <section class="panel">
             <div class="panel-head">
               <h2 data-i18n="servers.title">Upstream servers</h2>
@@ -437,11 +451,13 @@
               <p class="muted" id="servers-note"></p>
             </div>
           </section>
+        </section>
 
-          <!-- The mode in the header says whether this machine takes work at
-               all. This says when, so nobody has to be sitting here to switch
-               it back. Both only ever hold jobs back — a run started here, and
-               ComfyUI itself, are untouched. -->
+        <!-- The mode in the header says whether this machine takes work at
+             all. This says when, so nobody has to be sitting here to switch
+             it back. Both only ever hold jobs back — a run started here, and
+             ComfyUI itself, are untouched. -->
+        <section class="page" data-page="accepting" hidden>
           <section class="panel">
             <div class="panel-head"><h2 data-i18n="accept.title">Accepting jobs</h2></div>
             <p class="muted" data-i18n="accept.help"></p>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -103,6 +103,9 @@
                 <span class="muted" data-i18n="mode.pausedNote"></span>
               </span>
             </button>
+            <!-- What is holding jobs back while the mode above says they are
+                 welcome: a pause running out, or the wrong time of day. -->
+            <p class="muted" id="mode-gate"></p>
             <p class="muted" id="mode-note"></p>
           </div>
         </div>
@@ -410,6 +413,50 @@
               </button>
               <p class="muted" id="servers-note"></p>
             </div>
+          </section>
+
+          <!-- The mode in the header says whether this machine takes work at
+               all. This says when, so nobody has to be sitting here to switch
+               it back. Both only ever hold jobs back — a run started here, and
+               ComfyUI itself, are untouched. -->
+          <section class="panel">
+            <div class="panel-head"><h2 data-i18n="accept.title">Accepting jobs</h2></div>
+            <p class="muted" data-i18n="accept.help"></p>
+
+            <p class="popover-label" data-i18n="accept.pauseFor">Hold off for</p>
+            <div class="actions" id="accept-pause">
+              <button type="button" class="ghost" data-pause="15" data-i18n="accept.pause15">
+                15 min
+              </button>
+              <button type="button" class="ghost" data-pause="30" data-i18n="accept.pause30">
+                30 min
+              </button>
+              <button type="button" class="ghost" data-pause="60" data-i18n="accept.pause60">
+                1 hour
+              </button>
+              <button type="button" class="ghost" data-pause="0" data-i18n="accept.resume">
+                Resume now
+              </button>
+            </div>
+            <p class="muted" id="accept-pause-state"></p>
+
+            <p class="popover-label" data-i18n="accept.schedule">Every day</p>
+            <label class="check">
+              <input type="checkbox" id="accept-enabled" />
+              <span data-i18n="accept.scheduleOn">Only accept between these times</span>
+            </label>
+            <div class="row">
+              <label class="field">
+                <span data-i18n="accept.from">From</span>
+                <input type="time" id="accept-from" />
+              </label>
+              <label class="field">
+                <span data-i18n="accept.to">To</span>
+                <input type="time" id="accept-to" />
+              </label>
+            </div>
+            <p class="muted" data-i18n="accept.overnight"></p>
+            <p class="muted" id="accept-note"></p>
           </section>
         </section>
       </main>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -405,6 +405,29 @@
               </button>
             </div>
             <p class="muted" data-i18n="servers.help"></p>
+            <div class="link">
+              <p class="muted" data-i18n="servers.linkHelp"></p>
+              <div class="row">
+                <label class="field">
+                  <span data-i18n="servers.linkUrl">Server URL</span>
+                  <input type="text" id="link-url" placeholder="https://queue.example.com" />
+                </label>
+                <label class="field">
+                  <span data-i18n="servers.linkCode">Link code</span>
+                  <input
+                    type="text"
+                    id="link-code"
+                    placeholder="XXXX-XXXX-XXXX"
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                </label>
+              </div>
+              <div class="actions">
+                <button type="button" id="server-link" data-i18n="servers.link">Link</button>
+                <p class="muted" id="link-note"></p>
+              </div>
+            </div>
             <div id="servers"></div>
             <div class="actions">
               <button type="button" id="servers-save" data-i18n="servers.save">Save servers</button>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -12,6 +12,7 @@ import {
   removeJob,
   startJob,
 } from "../jobs";
+import { latestProgress } from "../progress";
 import { RUN_MODES, loadSettings, newUpstreamId, publicUpstreams, saveSettings } from "../settings";
 import { latestStatus, refreshStatus } from "../status";
 import {
@@ -52,6 +53,7 @@ async function handleState(): Promise<Response> {
     settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
     mode: settings.mode,
     accepting: acceptState(settings),
+    progress: latestProgress(),
     desktop: settings.desktop,
     jobs: listJobs(),
   });

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1,3 +1,4 @@
+import { MAX_PAUSE_MINUTES, acceptState, isTimeOfDay, pauseUntil } from "../accepting";
 import { agentSnapshot, applyUpstreamChange } from "../agent";
 import { interrupt, uploadImage, viewUrl } from "../comfy";
 import { comfyProcessState, startComfy, stopComfy } from "../comfy-process";
@@ -25,7 +26,7 @@ import {
 } from "../workflow";
 import { authorise } from "./guard";
 import index from "./index.html";
-import type { RunMode, UpstreamConfig } from "../settings";
+import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
 import type { RunParams } from "../types";
 
 function message(err: unknown): string {
@@ -49,6 +50,7 @@ async function handleState(): Promise<Response> {
     upstreams: publicUpstreams(settings),
     settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
     mode: settings.mode,
+    accepting: acceptState(settings),
     desktop: settings.desktop,
     jobs: listJobs(),
   });
@@ -202,6 +204,57 @@ async function handleMode(req: Request): Promise<Response> {
       await refreshStatus();
     }
     return Response.json({ mode: saved.mode });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * Hold off claiming for a while, then let it resume on its own. `0` minutes
+ * (or `null`) clears a pause that is still running.
+ *
+ * Deliberately not folded into `/api/mode`: the mode is what someone decided
+ * this machine is for, and a pause is a detour from it that ends by itself.
+ */
+async function handlePause(req: Request): Promise<Response> {
+  try {
+    const { minutes } = (await req.json()) as { minutes?: unknown };
+    const value = minutes === null || minutes === undefined ? 0 : minutes;
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return fail("minutes must be a number");
+    }
+    if (value < 0 || value > MAX_PAUSE_MINUTES) {
+      return fail(`minutes must be between 0 and ${MAX_PAUSE_MINUTES}`);
+    }
+
+    const saved = await saveSettings({ pauseUntil: pauseUntil(value) });
+    return Response.json({ accepting: acceptState(saved) });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * The daily window. Saved field by field like the desktop switches, so turning
+ * the window on does not need the times sent again, and fixing a time does not
+ * need the switch sent again.
+ */
+async function handleScheduleSave(req: Request): Promise<Response> {
+  try {
+    const body = (await req.json()) as Partial<AcceptSchedule>;
+    const current = (await loadSettings()).schedule;
+
+    if (body.enabled !== undefined && typeof body.enabled !== "boolean") {
+      return fail("enabled must be true or false");
+    }
+    const from = body.from ?? current.from;
+    const to = body.to ?? current.to;
+    if (!isTimeOfDay(from) || !isTimeOfDay(to)) return fail("from and to must be HH:MM");
+
+    const saved = await saveSettings({
+      schedule: { enabled: body.enabled ?? current.enabled, from, to },
+    });
+    return Response.json({ accepting: acceptState(saved) });
   } catch (err) {
     return fail(err);
   }
@@ -414,6 +467,8 @@ export function startUi() {
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
       "/api/mode": { POST: guarded(handleMode) },
+      "/api/accept/pause": { POST: guarded(handlePause) },
+      "/api/accept/schedule": { POST: guarded(handleScheduleSave) },
       "/api/desktop": { POST: guarded(handleDesktopSave) },
       "/api/comfy/start": { POST: guarded(handleComfyStart) },
       "/api/comfy/stop": { POST: guarded(handleComfyStop) },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -13,12 +13,14 @@ import {
   removeJob,
   startJob,
 } from "../jobs";
+import { outputsSnapshot, rescanOutputs, trimOutputs } from "../outputs";
 import { latestProgress } from "../progress";
 import {
   RUN_MODES,
   hostFromUrl,
   loadSettings,
   newUpstreamId,
+  normaliseCleanupDays,
   publicUpstreams,
   saveSettings,
 } from "../settings";
@@ -58,7 +60,12 @@ async function handleState(): Promise<Response> {
     activeWorkflow: await activeWorkflowName(),
     agent: agentSnapshot(),
     upstreams: publicUpstreams(settings),
-    settings: { comfyDir: settings.comfyDir, comfyCommand: settings.comfyCommand },
+    settings: {
+      comfyDir: settings.comfyDir,
+      comfyCommand: settings.comfyCommand,
+      outputCleanupDays: settings.outputCleanupDays,
+    },
+    outputs: outputsSnapshot(),
     mode: settings.mode,
     accepting: acceptState(settings),
     progress: latestProgress(),
@@ -265,14 +272,43 @@ async function handleLink(req: Request): Promise<Response> {
 
 async function handleSettingsSave(req: Request): Promise<Response> {
   try {
-    const body = (await req.json()) as { comfyDir?: string; comfyCommand?: string };
+    const body = (await req.json()) as {
+      comfyDir?: string;
+      comfyCommand?: string;
+      outputCleanupDays?: unknown;
+    };
     const saved = await saveSettings({
       ...(body.comfyDir === undefined ? {} : { comfyDir: body.comfyDir.trim() }),
       ...(body.comfyCommand === undefined ? {} : { comfyCommand: body.comfyCommand.trim() }),
+      ...(body.outputCleanupDays === undefined
+        ? {}
+        : { outputCleanupDays: normaliseCleanupDays(body.outputCleanupDays) }),
     });
+    // A different directory means a different output folder to count.
+    if (body.comfyDir !== undefined) void rescanOutputs();
     return Response.json({
-      settings: { comfyDir: saved.comfyDir, comfyCommand: saved.comfyCommand },
+      settings: {
+        comfyDir: saved.comfyDir,
+        comfyCommand: saved.comfyCommand,
+        outputCleanupDays: saved.outputCleanupDays,
+      },
     });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * Delete outputs older than the given days, right now. The stored rule is the
+ * quiet version of this; the button wants its result in the response.
+ */
+async function handleOutputsTrim(req: Request): Promise<Response> {
+  try {
+    const { days } = (await req.json()) as { days?: unknown };
+    if (typeof days !== "number" || !Number.isFinite(days) || days < 1 || days > 3650) {
+      return fail("days must be a number between 1 and 3650");
+    }
+    return Response.json(await trimOutputs(Math.floor(days)));
   } catch (err) {
     return fail(err);
   }
@@ -571,6 +607,7 @@ export function startUi() {
       "/api/link": { POST: guarded(handleLink) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
+      "/api/outputs/trim": { POST: guarded(handleOutputsTrim) },
       "/api/mode": { POST: guarded(handleMode) },
       "/api/accept/pause": { POST: guarded(handlePause) },
       "/api/accept/schedule": { POST: guarded(handleScheduleSave) },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -190,10 +190,10 @@ async function handleUpstreamTest(req: Request): Promise<Response> {
     const secret = (input.secret ?? "").trim() || stored?.secret || "";
     if (!secret) return fail("a secret is needed");
 
-    const { comfyStatus, queueRunning, queuePending } = latestStatus();
+    const { comfyStatus, queueRunning, queuePending, gpu } = latestStatus();
     const result = await testUpstream(
       { name: url, url, hostId, secret },
-      { comfyStatus, queueRunning, queuePending },
+      { comfyStatus, queueRunning, queuePending, gpu },
     );
     return Response.json(result);
   } catch (err) {

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -36,6 +36,7 @@ import {
   setActiveWorkflow,
 } from "../workflow";
 import { claimLinkCode, testUpstream } from "../upstream";
+import { checkWorkflow } from "../validate";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -111,6 +112,17 @@ async function handleWorkflowUpload(req: Request): Promise<Response> {
 
     const summary = await saveWorkflowFile(name, await file.text());
     return Response.json({ workflow: summary });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/** Compare one workflow against the running ComfyUI — see `validate.ts`. */
+async function handleWorkflowCheck(req: Request): Promise<Response> {
+  try {
+    const { name } = (await req.json()) as { name?: string };
+    if (!name) return fail("name is required");
+    return Response.json(await checkWorkflow(name));
   } catch (err) {
     return fail(err);
   }
@@ -600,6 +612,7 @@ export function startUi() {
       "/api/workflows/active": { POST: guarded(handleSetActive) },
       "/api/workflows/reload": { POST: guarded(handleReload) },
       "/api/workflows/upload": { POST: guarded(handleWorkflowUpload) },
+      "/api/workflows/check": { POST: guarded(handleWorkflowCheck) },
       "/api/workflows/delete": { POST: guarded(handleWorkflowDelete) },
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -3,6 +3,7 @@ import { agentSnapshot, applyUpstreamChange } from "../agent";
 import { interrupt, uploadImage, viewUrl } from "../comfy";
 import { comfyProcessState, startComfy, stopComfy } from "../comfy-process";
 import { COMFY_URL, UI_HOSTNAME, UI_PORT, UI_TOKEN, WORKFLOW_DIR } from "../config";
+import { listEvents } from "../events";
 import {
   clearFinishedJobs,
   completeJob,
@@ -63,6 +64,7 @@ async function handleState(): Promise<Response> {
     progress: latestProgress(),
     desktop: settings.desktop,
     jobs: listJobs(),
+    events: listEvents(),
   });
 }
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -13,7 +13,14 @@ import {
   startJob,
 } from "../jobs";
 import { latestProgress } from "../progress";
-import { RUN_MODES, loadSettings, newUpstreamId, publicUpstreams, saveSettings } from "../settings";
+import {
+  RUN_MODES,
+  hostFromUrl,
+  loadSettings,
+  newUpstreamId,
+  publicUpstreams,
+  saveSettings,
+} from "../settings";
 import { latestStatus, refreshStatus } from "../status";
 import {
   activeWorkflowName,
@@ -25,7 +32,7 @@ import {
   saveWorkflowFile,
   setActiveWorkflow,
 } from "../workflow";
-import { testUpstream } from "../upstream";
+import { claimLinkCode, testUpstream } from "../upstream";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -189,6 +196,62 @@ async function handleUpstreamTest(req: Request): Promise<Response> {
       { comfyStatus, queueRunning, queuePending },
     );
     return Response.json(result);
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * Link this machine to a job server with a one-time code issued by that
+ * server's own UI.
+ *
+ * The exchange happens here and not in the page for two reasons: the browser
+ * has no CORS grant from a job server it has never spoken to, and the secret
+ * that comes back has no business passing through the UI at all.
+ */
+async function handleLink(req: Request): Promise<Response> {
+  try {
+    const body = (await req.json()) as { url?: string; code?: string };
+    const url = (body.url ?? "").trim().replace(/\/$/, "");
+    const code = (body.code ?? "").trim();
+
+    if (!url) return fail("a server URL is required");
+    if (!/^https?:\/\//i.test(url))
+      return fail("the server URL must start with http:// or https://");
+    if (!code) return fail("a link code is required");
+
+    const linked = await claimLinkCode(url, code);
+
+    // One row per server URL. Linking the same server again replaces the
+    // credentials rather than leaving a second row claiming beside the first.
+    const settings = await loadSettings();
+    const known = settings.upstreams.some((server) => server.url === url);
+    const upstreams = known
+      ? settings.upstreams.map((server) =>
+          server.url === url
+            ? { ...server, hostId: linked.hostId, secret: linked.hostSecret }
+            : server,
+        )
+      : [
+          ...settings.upstreams,
+          {
+            id: newUpstreamId(),
+            name: hostFromUrl(url),
+            url,
+            hostId: linked.hostId,
+            secret: linked.hostSecret,
+            enabled: true,
+          },
+        ];
+
+    const saved = await saveSettings({ upstreams });
+    await applyUpstreamChange();
+
+    return Response.json({
+      upstreams: publicUpstreams(saved),
+      hostName: linked.hostName ?? null,
+      replaced: known,
+    });
   } catch (err) {
     return fail(err);
   }
@@ -503,6 +566,7 @@ export function startUi() {
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },
       "/api/upstreams/test": { POST: guarded(handleUpstreamTest) },
+      "/api/link": { POST: guarded(handleLink) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
       "/api/mode": { POST: guarded(handleMode) },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -24,6 +24,7 @@ import {
   saveWorkflowFile,
   setActiveWorkflow,
 } from "../workflow";
+import { testUpstream } from "../upstream";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
@@ -151,6 +152,41 @@ async function handleUpstreamsSave(req: Request): Promise<Response> {
     const saved = await saveSettings({ upstreams });
     await applyUpstreamChange();
     return Response.json({ upstreams: publicUpstreams(saved) });
+  } catch (err) {
+    return fail(err);
+  }
+}
+
+/**
+ * One heartbeat to a single server, sent now, so a wrong secret says so instead
+ * of looking like an unreachable host until the next scheduled beat.
+ *
+ * The row is taken as it stands on screen: a secret typed but not yet saved is
+ * what gets tested, and a blank one falls back to the stored value — the same
+ * rule the save path uses, so testing and saving cannot disagree about which
+ * secret they mean.
+ */
+async function handleUpstreamTest(req: Request): Promise<Response> {
+  try {
+    const input = (await req.json()) as UpstreamInput;
+    const settings = await loadSettings();
+    const stored = input.id
+      ? settings.upstreams.find((server) => server.id === input.id)
+      : undefined;
+
+    const url = (input.url ?? stored?.url ?? "").trim().replace(/\/$/, "");
+    if (!url) return fail("a URL is needed");
+    const hostId = (input.hostId ?? stored?.hostId ?? "").trim();
+    if (!hostId) return fail("a host id is needed");
+    const secret = (input.secret ?? "").trim() || stored?.secret || "";
+    if (!secret) return fail("a secret is needed");
+
+    const { comfyStatus, queueRunning, queuePending } = latestStatus();
+    const result = await testUpstream(
+      { name: url, url, hostId, secret },
+      { comfyStatus, queueRunning, queuePending },
+    );
+    return Response.json(result);
   } catch (err) {
     return fail(err);
   }
@@ -464,6 +500,7 @@ export function startUi() {
       "/api/workflows/delete": { POST: guarded(handleWorkflowDelete) },
 
       "/api/upstreams": { POST: guarded(handleUpstreamsSave) },
+      "/api/upstreams/test": { POST: guarded(handleUpstreamTest) },
 
       "/api/settings": { POST: guarded(handleSettingsSave) },
       "/api/mode": { POST: guarded(handleMode) },

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -708,6 +708,12 @@ input[type="file"]::file-selector-button {
   cursor: pointer;
 }
 
+.link {
+  margin-bottom: var(--space-2xs);
+  padding-bottom: var(--space-2xs);
+  border-bottom: 1px solid var(--border);
+}
+
 .row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -912,6 +912,23 @@ button.ghost.danger:hover:not(:disabled) {
   accent-color: var(--primary);
 }
 
+/* How far along the run in flight is, when ComfyUI is counting steps. */
+.bar {
+  height: 0.375rem;
+  margin-top: var(--space-2xs);
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: var(--muted);
+}
+
+.bar > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--primary);
+  transition: width var(--dur-mid) var(--ease-out);
+}
+
 /* The child process's own words, so a wrong command explains itself. */
 .log {
   max-height: 14rem;

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -972,6 +972,36 @@ button.ghost.danger:hover:not(:disabled) {
   background: var(--canvas);
 }
 
+/* Narrowing the run history, and switching how it is drawn. */
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  margin-bottom: var(--space-2xs);
+}
+
+/* Every picture the filtered runs produced, packed edge to edge. */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: var(--space-2xs);
+}
+
+.gallery .cell {
+  display: block;
+}
+
+.gallery img,
+.gallery video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--canvas);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -14,6 +14,11 @@
  * - `POST /jobs/:jobId/result`        — upload the produced file as the raw body
  * - `POST /jobs/:jobId/complete`      — mark done
  * - `POST /jobs/:jobId/fail`          — mark failed with `{ reason }`
+ *
+ * Linking adds one more, outside the per-host block and unauthenticated
+ * because the code it takes is itself the credential:
+ *
+ * - `POST /api/internal/hosts/link`     — trade a one-time code for `{ hostId, hostSecret }`
  */
 
 import type { Settings, UpstreamConfig } from "./settings";
@@ -45,6 +50,42 @@ function toServer(config: UpstreamConfig): UpstreamServer {
     hostId: config.hostId,
     secret: config.secret,
   };
+}
+
+export type LinkedHost = {
+  hostId: string;
+  hostSecret: string;
+  /** What the server calls this host, so the UI can confirm what was linked. */
+  hostName?: string;
+};
+
+/**
+ * Trade a one-time code, issued by the job server's own UI, for this machine's
+ * credentials.
+ *
+ * This is the alternative to carrying a host id and a secret across by hand.
+ * The code is short-lived and spent on use, so it is safe to read off a screen
+ * in a way the secret it buys is not — which is why the secret is fetched here
+ * rather than shown to whoever is registering the machine.
+ */
+export async function claimLinkCode(url: string, code: string): Promise<LinkedHost> {
+  const res = await fetch(`${url}/api/internal/hosts/link`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `the server refused the code: HTTP ${res.status}`);
+  }
+
+  const linked = (await res.json()) as Partial<LinkedHost>;
+  if (!linked.hostId || !linked.hostSecret) {
+    throw new Error("the server accepted the code but sent no credentials");
+  }
+  return { hostId: linked.hostId, hostSecret: linked.hostSecret, hostName: linked.hostName };
 }
 
 function authHeaders(server: UpstreamServer): Record<string, string> {

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -81,6 +81,60 @@ export async function sendHeartbeat(
   }
 }
 
+export type UpstreamTest = {
+  ok: boolean;
+  /** Round trip in milliseconds, however it ended. */
+  ms: number;
+  /** Jobs waiting for this host, when the server said. */
+  pendingJobs?: number;
+  /** Why it failed, as close to the server's own words as there are any. */
+  error?: string;
+};
+
+/** Enough of a rejection to tell a wrong secret from a wrong address. */
+const REASON_LIMIT = 120;
+
+/**
+ * One heartbeat, sent now, answering with why it failed rather than logging it.
+ *
+ * A separate call from {@link sendHeartbeat} on purpose: that one swallows
+ * failures because the poll loop must carry on regardless, and someone who has
+ * just typed a secret in wants the opposite — the status code, in the row.
+ */
+export async function testUpstream(
+  server: UpstreamServer,
+  status: ComfyStatusResult,
+): Promise<UpstreamTest> {
+  const started = Date.now();
+
+  try {
+    const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/heartbeat`, {
+      method: "POST",
+      headers: authHeaders(server),
+      body: JSON.stringify(status),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const ms = Date.now() - started;
+
+    if (!res.ok) {
+      const reason = (await res.text().catch(() => "")).trim().slice(0, REASON_LIMIT);
+      return {
+        ok: false,
+        ms,
+        error: reason ? `HTTP ${res.status} ${reason}` : `HTTP ${res.status}`,
+      };
+    }
+    const ack = (await res.json()) as HeartbeatAck;
+    return { ok: true, ms, pendingJobs: ack.pendingJobs };
+  } catch (err) {
+    return {
+      ok: false,
+      ms: Date.now() - started,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export async function claimJob(server: UpstreamServer): Promise<ClaimedJob | null> {
   try {
     const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/jobs/claim`, {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,113 @@
+/**
+ * Check a workflow against the ComfyUI it would run on, without running it.
+ *
+ * A workflow that names a model or a custom node this machine does not have
+ * fails only when a run reaches that node — minutes in, after a claim. ComfyUI
+ * already knows everything needed to say so up front: `/object_info` lists
+ * every installed node class, and for each combo input the exact choices on
+ * offer (which is where checkpoints, LoRAs and VAEs live). This compares the
+ * workflow's literal values against that list.
+ *
+ * Inputs the app rewrites at run time — the detected slots, the input image
+ * above all — are left out: their stored value is about to be replaced, so its
+ * absence proves nothing.
+ */
+
+import { COMFY_URL } from "./config";
+import { loadWorkflow } from "./workflow";
+import type { Slot, WorkflowSlots } from "./slots";
+
+type InputSpec = unknown[];
+
+type ObjectInfo = Record<
+  string,
+  {
+    input?: {
+      required?: Record<string, InputSpec>;
+      optional?: Record<string, InputSpec>;
+    };
+  }
+>;
+
+/**
+ * `/object_info` is megabytes and changes only when models or nodes are
+ * installed, so one minute of reuse spares ComfyUI without going stale enough
+ * to mislead anyone.
+ */
+const OBJECT_INFO_TTL_MS = 60_000;
+
+let cached: { at: number; info: ObjectInfo } | null = null;
+
+async function objectInfo(): Promise<ObjectInfo> {
+  if (cached && Date.now() - cached.at < OBJECT_INFO_TTL_MS) return cached.info;
+
+  let res: Response;
+  try {
+    res = await fetch(`${COMFY_URL}/object_info`, { signal: AbortSignal.timeout(30_000) });
+  } catch {
+    throw new Error("ComfyUI is not answering — start it before checking");
+  }
+  if (!res.ok) throw new Error(`ComfyUI /object_info failed: HTTP ${res.status}`);
+
+  const info = (await res.json()) as ObjectInfo;
+  cached = { at: Date.now(), info };
+  return info;
+}
+
+function slotRefs(slots: WorkflowSlots): Set<string> {
+  const refs = new Set<string>();
+  const add = (slot: Slot | null) => {
+    if (slot) refs.add(`${slot.nodeId}:${slot.input}`);
+  };
+  add(slots.image);
+  add(slots.positive);
+  add(slots.negative);
+  add(slots.length);
+  add(slots.frameRate);
+  for (const seed of slots.seed) add(seed);
+  return refs;
+}
+
+export type WorkflowCheck = {
+  ok: boolean;
+  /** Worded server-side, like every other error the UI passes through. */
+  problems: string[];
+  checkedNodes: number;
+};
+
+export async function checkWorkflow(name: string): Promise<WorkflowCheck> {
+  const loaded = await loadWorkflow(name);
+  const info = await objectInfo();
+  const replaced = slotRefs(loaded.slots);
+
+  const problems: string[] = [];
+
+  for (const [nodeId, node] of Object.entries(loaded.workflow)) {
+    const spec = info[node.class_type];
+    if (!spec) {
+      problems.push(`node ${nodeId}: ${node.class_type} is not installed in this ComfyUI`);
+      continue;
+    }
+
+    const inputSpecs = { ...spec.input?.required, ...spec.input?.optional };
+    for (const [inputName, value] of Object.entries(node.inputs)) {
+      // Combo choices are strings; anything else is a number, a link, or text.
+      if (typeof value !== "string") continue;
+      if (replaced.has(`${nodeId}:${inputName}`)) continue;
+
+      const choices = inputSpecs[inputName]?.[0];
+      if (!Array.isArray(choices) || !choices.every((entry) => typeof entry === "string")) {
+        continue;
+      }
+      if (choices.includes(value)) continue;
+
+      problems.push(
+        choices.length === 0
+          ? `node ${nodeId} (${node.class_type}): ${inputName} "${value}" — this ComfyUI has nothing installed to choose from`
+          : `node ${nodeId} (${node.class_type}): ${inputName} "${value}" is not among the ${choices.length} choices this ComfyUI offers`,
+      );
+    }
+  }
+
+  return { ok: problems.length === 0, problems, checkedNodes: Object.keys(loaded.workflow).length };
+}


### PR DESCRIPTION
0.2.0 のリリースマージです。マージすると Release ワークフローが起動し、Windows インストーラーをビルドして **draft リリース v0.2.0**(署名付きアップデートアーティファクト + `latest.json` 同梱)を作ります。draft を publish した時点で公開です。

**0.1.2 からの変更**

- タブ分割 UI(#19)
- ComfyUI の自動再起動 watchdog(#27)
- ステータスバーに VRAM 表示(#28)
- 失敗・切断のデスクトップ通知(#29)
- 上流ジョブの自動リトライ(#30)
- 出力フォルダの使用量表示と自動削除(#31)
- 実行履歴のフィルタとギャラリー表示(#32)
- ワークフローの事前検証(#33)
- GitHub Releases からの自動アップデート(#36)

**注意**

- 0.1.2 には updater が入っていないため、既存ユーザーへ自動では届きません。0.2.0 を手動で入れてもらえば、以降のリリースは自動で届きます。
- publish 前に、リリースアセットに `latest.json` と `*.sig` が付いていることを確認してください(署名シークレットが効いている証拠です)。