### PR TITLE
chore(agent): tidy comments and rename the model ledger file

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -64,7 +64,7 @@ function message(err: unknown): string {
 async function sendHeartbeats() {
   const status = await refreshStatus();
   // Which preset models this host holds, verified. The server assigns preset
-  // jobs only to hosts whose set covers the preset (douga-workflow #127).
+  // jobs only to hosts whose set covers the preset.
   const payload = { ...status, readyModels: getReadyModels() };
 
   await Promise.all(
@@ -105,7 +105,7 @@ async function claimNext(): Promise<{ server: UpstreamServer; job: ClaimedJob } 
 }
 
 async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
-  // A workflow object rides inside the claim (douga-workflow #127): run that,
+  // A workflow object rides inside the claim: run that,
   // not a local file. Strings and absence keep the existing local-file path.
   if (claimed.workflow && typeof claimed.workflow === "object") {
     await processServerWorkflowJob(server, claimed, claimed.workflow);

--- a/src/models.ts
+++ b/src/models.ts
@@ -5,7 +5,7 @@ import type { UpstreamServer } from "./upstream";
 
 /**
  * Keeps the local models/ directory in step with what upstream servers say
- * their workflow presets need (douga-workflow #127).
+ * their workflow presets need.
  *
  * A server hands out a manifest of models (URL + sha256 + destination), this
  * side downloads what is missing, verifies it, and reports what it holds in
@@ -19,7 +19,7 @@ import type { UpstreamServer } from "./upstream";
  */
 
 /** Verified-hash ledger, so a restart does not re-hash tens of gigabytes. */
-const STATE_FILE = ".douga-models.json";
+const STATE_FILE = ".preset-models.json";
 
 export type ManifestModel = {
   filename: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export type JobRecord = {
 };
 
 /**
- * A workflow shipped inside the claim itself (douga-workflow #127). The JSON is
+ * A workflow shipped inside the claim itself by the upstream server. The JSON is
  * API format; placeholders (`__INPUT_IMAGE__`, `__TRIGGER_WORDS__`, `__SEED__`)
  * are substituted here before queueing.
  */

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -273,7 +273,7 @@ export async function runWorkflow(
 }
 
 /**
- * Placeholders a server-supplied workflow may carry (douga-workflow #127).
+ * Placeholders a server-supplied workflow may carry.
  * Node ids differ per workflow, so the substitution points are marked in the
  * JSON itself; this walks every node's inputs and swaps values, never touching
  * the graph's structure.


### PR DESCRIPTION
## 変更内容

#41 のコメントに残っていた内部向けの参照を外し、検証済みモデルの控えファイルを
`.preset-models.json` に改名した。挙動の変更はない。

改名の影響: 旧名の控えを持つホストは、次回同期で各モデルを一度だけ再ハッシュして
新しい控えを作り直す(ダウンロードは発生しない)。旧ファイルは残るが無害で、消してよい。

## 確認したこと

- [x] `bun run check:ci` / `tsc --noEmit`
- [x] 差分はコメント 5 行と定数 1 つだけで、ロジックに触れていないことを diff で確認