### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-comfyui-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A ComfyUI job runner with a web management UI. Bring your own API-format workflow.",
   "license": "MIT",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop-comfyui-server"
-version = "0.2.0"
+version = "0.3.0"
 description = "Desktop shell for the ComfyUI job runner"
 edition = "2021"
 rust-version = "1.77.2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Desktop ComfyUI Server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "dev.mintani.desktop-comfyui-server",
   "build": {
     "beforeDevCommand": "bun run build:sidecar",


### PR DESCRIPTION
Closes #43

`bun run bump 0.3.0` — writes the version into `package.json`,
`src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` together, the way the
release workflow expects them.

## What 0.3.0 ships

Everything on `dev` since 0.2.0:

- **Preset model sync and server-supplied workflows** (#41) — the agent fetches
  each upstream's manifest, downloads missing models (verified by sha256, with
  an mtime-aware ledger so restarts do not re-hash tens of gigabytes), reports
  what it holds via the heartbeat, and runs workflows the server attaches to a
  job instead of only the bundled one.
- **Node-definition reporting** (#41/#42) — the agent posts ComfyUI's
  `/object_info` to every upstream whenever it changes, which is what an
  upstream's workflow editor needs before it can offer a node palette.

## Why now

Installed agents update from published releases only. Until this ships, every
upstream waits for node definitions that never arrive, and preset jobs cannot
be assigned to any host.

MINOR bump per CONTRIBUTING (new features, pre-1.0): `0.2.0 → 0.3.0`.

## Checks

- [x] `bun run check:ci` / `bun run check-types`
- [x] The three version files agree (the release workflow refuses to build
      otherwise)

## After this lands

Merge `dev` into `main` (#45 is open for that) — the release workflow then
builds the installers and opens the `v0.3.0` draft. Publishing the draft is the
switch that makes installed agents offer the update.