### PR TITLE
chore(release): ship 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-comfyui-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A ComfyUI job runner with a web management UI. Bring your own API-format workflow.",
   "license": "MIT",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop-comfyui-server"
-version = "0.2.0"
+version = "0.3.0"
 description = "Desktop shell for the ComfyUI job runner"
 edition = "2021"
 rust-version = "1.77.2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Desktop ComfyUI Server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "dev.mintani.desktop-comfyui-server",
   "build": {
     "beforeDevCommand": "bun run build:sidecar",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -64,7 +64,7 @@ function message(err: unknown): string {
 async function sendHeartbeats() {
   const status = await refreshStatus();
   // Which preset models this host holds, verified. The server assigns preset
-  // jobs only to hosts whose set covers the preset (douga-workflow #127).
+  // jobs only to hosts whose set covers the preset.
   const payload = { ...status, readyModels: getReadyModels() };
 
   await Promise.all(
@@ -105,7 +105,7 @@ async function claimNext(): Promise<{ server: UpstreamServer; job: ClaimedJob } 
 }
 
 async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
-  // A workflow object rides inside the claim (douga-workflow #127): run that,
+  // A workflow object rides inside the claim: run that,
   // not a local file. Strings and absence keep the existing local-file path.
   if (claimed.workflow && typeof claimed.workflow === "object") {
     await processServerWorkflowJob(server, claimed, claimed.workflow);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,6 +6,7 @@ import {
   COMFY_URL,
   HEARTBEAT_INTERVAL_MS,
   JOB_RETRIES,
+  MODEL_SYNC_INTERVAL_MS,
   POLL_INTERVAL_MS,
   RETRY_DELAY_MS,
   UPDATE_CHECK_INTERVAL_MS,
@@ -23,7 +24,8 @@ import {
   sendHeartbeat,
   uploadResult,
 } from "./upstream";
-import { activeWorkflowName, runWorkflow } from "./workflow";
+import { fetchManifest, getReadyModels, reportObjectInfo, syncModels } from "./models";
+import { activeWorkflowName, runServerWorkflow, runWorkflow } from "./workflow";
 import type { UpstreamServer } from "./upstream";
 import type { ClaimedJob } from "./types";
 
@@ -39,6 +41,7 @@ let running = false;
 /** True while `pollLoop` is between its start and its `finally`. */
 let loopActive = false;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let modelSyncTimer: ReturnType<typeof setInterval> | null = null;
 
 /** Upstream view for the UI. Secrets are deliberately not included. */
 export function agentSnapshot() {
@@ -60,13 +63,16 @@ function message(err: unknown): string {
 
 async function sendHeartbeats() {
   const status = await refreshStatus();
+  // Which preset models this host holds, verified. The server assigns preset
+  // jobs only to hosts whose set covers the preset (douga-workflow #127).
+  const payload = { ...status, readyModels: getReadyModels() };
 
   await Promise.all(
     upstreams.map(async (server) => {
       // What the last beat said, so only a change of state is announced.
       const was = heartbeats.get(server.name)?.ok;
 
-      const ack = await sendHeartbeat(server, status);
+      const ack = await sendHeartbeat(server, payload);
       if (!ack) {
         heartbeats.set(server.name, { ok: false, at: Date.now() });
         if (was !== false) pushEvent("upstream-down", { server: server.name });
@@ -99,6 +105,12 @@ async function claimNext(): Promise<{ server: UpstreamServer; job: ClaimedJob } 
 }
 
 async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
+  // A workflow object rides inside the claim (douga-workflow #127): run that,
+  // not a local file. Strings and absence keep the existing local-file path.
+  if (claimed.workflow && typeof claimed.workflow === "object") {
+    await processServerWorkflowJob(server, claimed, claimed.workflow);
+    return;
+  }
   const workflowName = claimed.workflow ?? (await activeWorkflowName());
   if (!workflowName) {
     const reason = "no workflow installed — drop an API-format workflow into workflows/";
@@ -173,6 +185,51 @@ async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
       await reportFailure(server, claimed.jobId, reason);
       return;
     }
+  }
+}
+
+async function processServerWorkflowJob(
+  server: UpstreamServer,
+  claimed: ClaimedJob,
+  spec: import("./types").ServerWorkflow,
+) {
+  const label = `preset:${spec.presetId}`;
+  console.log(`[worker] job ${claimed.jobId} started (${server.name}, ${label})`);
+  const job = startJob({
+    id: claimed.jobId,
+    source: "upstream",
+    origin: server.name,
+    workflow: label,
+  });
+
+  try {
+    let imageFilename: string | undefined;
+    if (claimed.sourceImageBase64) {
+      const contentType = claimed.sourceImageContentType || "image/png";
+      const ext = contentType.split("/")[1] ?? "png";
+      imageFilename = await uploadImage(
+        COMFY_URL,
+        `input_${claimed.jobId}.${ext}`,
+        contentType,
+        Buffer.from(claimed.sourceImageBase64, "base64"),
+      );
+    }
+
+    const outputs = await runServerWorkflow(spec, imageFilename, (promptId) =>
+      markQueued(job, promptId),
+    );
+
+    const primary = outputs.find((output) => output.kind === "video") ?? outputs[0]!;
+    await uploadResult(server, claimed.jobId, primary.url);
+    await reportComplete(server, claimed.jobId);
+
+    completeJob(job, outputs);
+    console.log(`[worker] job ${claimed.jobId} completed`);
+  } catch (err) {
+    const reason = message(err);
+    console.error(`[worker] job ${claimed.jobId} failed: ${reason}`);
+    failJob(job, reason);
+    await reportFailure(server, claimed.jobId, reason);
   }
 }
 
@@ -253,13 +310,29 @@ export function startAgent(servers: UpstreamServer[]): void {
   running = true;
   void sendHeartbeats();
   heartbeatTimer = setInterval(() => void sendHeartbeats(), HEARTBEAT_INTERVAL_MS);
+  // Model/node-definition sync runs on its own clock and never blocks jobs:
+  // preset jobs are only assigned once the server sees the models as ready.
+  void syncWithUpstreams();
+  modelSyncTimer = setInterval(() => void syncWithUpstreams(), MODEL_SYNC_INTERVAL_MS);
   void pollLoop();
+}
+
+async function syncWithUpstreams() {
+  const servers = upstreams;
+  if (servers.length === 0) return;
+  const manifests = (await Promise.all(servers.map(fetchManifest))).filter(
+    (manifest): manifest is NonNullable<typeof manifest> => manifest !== null,
+  );
+  if (manifests.length > 0) await syncModels(manifests);
+  await reportObjectInfo(COMFY_URL, servers);
 }
 
 export function stopAgent(): void {
   running = false;
   if (heartbeatTimer) clearInterval(heartbeatTimer);
   heartbeatTimer = null;
+  if (modelSyncTimer) clearInterval(modelSyncTimer);
+  modelSyncTimer = null;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,9 @@ export const UI_HOSTNAME = process.env.UI_HOSTNAME ?? "127.0.0.1";
 export const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS ?? "5000");
 export const HEARTBEAT_INTERVAL_MS = Number(process.env.HEARTBEAT_INTERVAL_MS ?? "30000");
 
+/** How often preset models and node definitions are synced with upstreams. */
+export const MODEL_SYNC_INTERVAL_MS = Number(process.env.MODEL_SYNC_INTERVAL_MS ?? "600000");
+
 /** How long a single ComfyUI run may take before it is abandoned. */
 export const JOB_TIMEOUT_MS = Number(process.env.JOB_TIMEOUT_MS ?? "600000");
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,337 @@
+import { mkdir, rename, rm, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { loadSettings } from "./settings";
+import type { UpstreamServer } from "./upstream";
+
+/**
+ * Keeps the local models/ directory in step with what upstream servers say
+ * their workflow presets need (douga-workflow #127).
+ *
+ * A server hands out a manifest of models (URL + sha256 + destination), this
+ * side downloads what is missing, verifies it, and reports what it holds in
+ * the heartbeat's `readyModels`. The server only assigns preset jobs to hosts
+ * that hold everything the preset needs, so a missing model never turns into
+ * a failed run.
+ *
+ * The models directory comes from the ComfyUI directory in settings
+ * (`<comfyDir>/models`), or `COMFY_MODELS_DIR` when set. With neither, sync
+ * stays off and everything else works as before.
+ */
+
+/** Verified-hash ledger, so a restart does not re-hash tens of gigabytes. */
+const STATE_FILE = ".douga-models.json";
+
+export type ManifestModel = {
+  filename: string;
+  url: string;
+  sha256: string;
+  sizeBytes: number;
+  dest: string;
+};
+
+export type Manifest = {
+  presets: Array<{ id: string; name: string; models: ManifestModel[] }>;
+};
+
+async function modelsDir(): Promise<string> {
+  const override = process.env.COMFY_MODELS_DIR;
+  if (override) return resolve(override);
+  const settings = await loadSettings();
+  return settings.comfyDir ? join(settings.comfyDir, "models") : "";
+}
+
+/** "dest/filename" — the key readiness is reported and judged by. */
+function keyOf(model: ManifestModel): string {
+  return `${model.dest}/${model.filename}`;
+}
+
+// The server validates too, but this side writes to the filesystem, so it
+// guards itself: names with separators or dots-only could point outside models/.
+function isSafeName(value: string): boolean {
+  return value.length > 0 && !/[/\\]/.test(value) && value !== ".." && value !== ".";
+}
+
+function isManifestModel(value: unknown): value is ManifestModel {
+  if (typeof value !== "object" || value === null) return false;
+  const m = value as Record<string, unknown>;
+  return (
+    typeof m.filename === "string" &&
+    isSafeName(m.filename) &&
+    typeof m.url === "string" &&
+    typeof m.sha256 === "string" &&
+    /^[0-9a-f]{64}$/.test(m.sha256) &&
+    typeof m.sizeBytes === "number" &&
+    typeof m.dest === "string" &&
+    isSafeName(m.dest)
+  );
+}
+
+export async function fetchManifest(server: UpstreamServer): Promise<Manifest | null> {
+  try {
+    const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/manifest`, {
+      headers: { Authorization: `Bearer ${server.secret}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      // Older servers have no manifest endpoint; that is not an error.
+      if (res.status !== 404) {
+        console.error(`[models] ${server.name} manifest rejected: HTTP ${res.status}`);
+      }
+      return null;
+    }
+    const body = (await res.json()) as { presets?: unknown };
+    if (!Array.isArray(body.presets)) return null;
+    const presets = body.presets.flatMap((preset) => {
+      if (typeof preset !== "object" || preset === null) return [];
+      const p = preset as Record<string, unknown>;
+      if (typeof p.id !== "string" || typeof p.name !== "string") return [];
+      const models = Array.isArray(p.models) ? p.models.filter(isManifestModel) : [];
+      return [{ id: p.id, name: p.name, models }];
+    });
+    return { presets };
+  } catch (err) {
+    console.error(
+      `[models] ${server.name} manifest error:`,
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Verified-hash ledger
+// ---------------------------------------------------------------------------
+
+// The ledger keeps mtime as well as the hash: a file replaced in place with the
+// same size still moves its mtime, so tampering or partial writes get caught
+// without re-hashing everything at every boot.
+type VerifiedEntry = { sha256: string; mtimeMs: number };
+type VerifiedState = Record<string, VerifiedEntry>;
+
+function isVerifiedEntry(value: unknown): value is VerifiedEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.sha256 === "string" && typeof entry.mtimeMs === "number";
+}
+
+async function loadState(dir: string): Promise<VerifiedState> {
+  try {
+    const file = Bun.file(join(dir, STATE_FILE));
+    if (!(await file.exists())) return {};
+    const parsed = (await file.json()) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const state: VerifiedState = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (isVerifiedEntry(value)) state[key] = value;
+    }
+    return state;
+  } catch {
+    return {};
+  }
+}
+
+async function saveState(dir: string, state: VerifiedState): Promise<void> {
+  await Bun.write(join(dir, STATE_FILE), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+async function hashFile(path: string): Promise<string> {
+  const hasher = new Bun.CryptoHasher("sha256");
+  const stream = Bun.file(path).stream();
+  for await (const chunk of stream) hasher.update(chunk);
+  return hasher.digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Sync
+// ---------------------------------------------------------------------------
+
+/** Keys of models held and verified. The heartbeat sends this as-is. */
+const ready = new Set<string>();
+
+export function getReadyModels(): string[] {
+  return [...ready].sort();
+}
+
+let syncing = false;
+let warnedNoDir = false;
+
+async function downloadModel(model: ManifestModel, target: string): Promise<void> {
+  const tmp = `${target}.part`;
+  const res = await fetch(model.url, { signal: AbortSignal.timeout(30 * 60_000) });
+  if (!res.ok || !res.body) throw new Error(`download failed: HTTP ${res.status}`);
+
+  // Hash while downloading; writing tens of gigabytes and then reading them
+  // back to hash would double the disk traffic.
+  const hasher = new Bun.CryptoHasher("sha256");
+  const writer = Bun.file(tmp).writer();
+  let written = 0;
+  for await (const chunk of res.body) {
+    hasher.update(chunk);
+    writer.write(chunk);
+    written += chunk.byteLength;
+  }
+  await writer.end();
+
+  const digest = hasher.digest("hex");
+  if (digest !== model.sha256) {
+    await rm(tmp, { force: true });
+    throw new Error(`sha256 mismatch (got ${digest.slice(0, 12)}…, ${written} bytes)`);
+  }
+  await rename(tmp, target);
+}
+
+/**
+ * Brings the local models into line with the manifests, one file at a time.
+ * Sequential on purpose: the sources hand out multi-gigabyte files, and
+ * parallel downloads only make failures harder to attribute. One failure
+ * does not stop the rest.
+ */
+export async function syncModels(manifests: Manifest[]): Promise<void> {
+  if (syncing) return;
+  const dir = await modelsDir();
+  if (!dir) {
+    if (!warnedNoDir) {
+      warnedNoDir = true;
+      console.log("[models] no ComfyUI directory configured — preset model sync disabled");
+    }
+    return;
+  }
+  syncing = true;
+  try {
+    // Merge manifests from every upstream. On a key collision with a different
+    // hash the first one wins — one path can only hold one file.
+    const wanted = new Map<string, ManifestModel>();
+    for (const manifest of manifests) {
+      for (const preset of manifest.presets) {
+        for (const model of preset.models) {
+          const key = keyOf(model);
+          const existing = wanted.get(key);
+          if (existing && existing.sha256 !== model.sha256) {
+            console.error(`[models] conflicting sha256 for ${key} — keeping the first one seen`);
+            continue;
+          }
+          wanted.set(key, model);
+        }
+      }
+    }
+    if (wanted.size === 0) return;
+
+    const state = await loadState(dir);
+
+    for (const [key, model] of wanted) {
+      if (ready.has(key)) continue;
+      const destDir = join(dir, model.dest);
+      const target = join(destDir, model.filename);
+      try {
+        await mkdir(destDir, { recursive: true });
+
+        const existing = await stat(target).catch(() => null);
+        if (existing) {
+          const noted = state[key];
+          // Size, noted hash and mtime all line up: nothing to re-read.
+          if (
+            existing.size === model.sizeBytes &&
+            noted?.sha256 === model.sha256 &&
+            noted.mtimeMs === existing.mtimeMs
+          ) {
+            ready.add(key);
+            continue;
+          }
+          // Right size but no (or stale) note: hash it once and record it.
+          if (existing.size === model.sizeBytes) {
+            console.log(`[models] verifying ${key} (${existing.size} bytes)`);
+            const digest = await hashFile(target);
+            if (digest === model.sha256) {
+              state[key] = { sha256: digest, mtimeMs: existing.mtimeMs };
+              await saveState(dir, state);
+              ready.add(key);
+              continue;
+            }
+            console.error(`[models] ${key} hash mismatch — re-downloading`);
+          } else {
+            console.error(
+              `[models] ${key} size mismatch (${existing.size} != ${model.sizeBytes}) — re-downloading`,
+            );
+          }
+          await rm(target, { force: true });
+          delete state[key];
+        }
+
+        console.log(`[models] downloading ${key} (${model.sizeBytes} bytes)`);
+        await downloadModel(model, target);
+        const downloaded = await stat(target);
+        state[key] = { sha256: model.sha256, mtimeMs: downloaded.mtimeMs };
+        await saveState(dir, state);
+        ready.add(key);
+        console.log(`[models] ${key} ready`);
+      } catch (err) {
+        console.error(`[models] ${key} failed:`, err instanceof Error ? err.message : err);
+      }
+    }
+  } finally {
+    syncing = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Node definitions
+// ---------------------------------------------------------------------------
+
+// Hash of the last object_info actually accepted somewhere, so an unchanged
+// node set is not re-uploaded (it runs to megabytes) every sync.
+let lastObjectInfoHash = "";
+
+/**
+ * Reports ComfyUI's `/object_info` to every upstream. The web workflow editor
+ * builds its node palette from this; execution never reads it. Failures stay
+ * out of the job path.
+ */
+export async function reportObjectInfo(comfyUrl: string, servers: UpstreamServer[]): Promise<void> {
+  let body: string;
+  try {
+    const res = await fetch(`${comfyUrl.replace(/\/$/, "")}/object_info`, {
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) return;
+    body = await res.text();
+  } catch {
+    // ComfyUI is simply down; the next cycle tries again.
+    return;
+  }
+
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(body);
+  const hash = hasher.digest("hex");
+  if (hash === lastObjectInfoHash) return;
+
+  let reported = false;
+  await Promise.all(
+    servers.map(async (server) => {
+      try {
+        const res = await fetch(`${server.url}/api/internal/hosts/${server.hostId}/object-info`, {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${server.secret}`,
+            "Content-Type": "application/json",
+          },
+          body,
+          signal: AbortSignal.timeout(60_000),
+        });
+        if (res.ok) reported = true;
+        // Older servers have no endpoint for this (404); that is not an error.
+        else if (res.status !== 404) {
+          console.error(`[models] ${server.name} object-info rejected: HTTP ${res.status}`);
+        }
+      } catch (err) {
+        console.error(
+          `[models] ${server.name} object-info error:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }),
+  );
+  if (reported) {
+    lastObjectInfoHash = hash;
+    console.log(`[models] object_info reported (${body.length} bytes)`);
+  }
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -5,7 +5,7 @@ import type { UpstreamServer } from "./upstream";
 
 /**
  * Keeps the local models/ directory in step with what upstream servers say
- * their workflow presets need (douga-workflow #127).
+ * their workflow presets need.
  *
  * A server hands out a manifest of models (URL + sha256 + destination), this
  * side downloads what is missing, verifies it, and reports what it holds in
@@ -19,7 +19,7 @@ import type { UpstreamServer } from "./upstream";
  */
 
 /** Verified-hash ledger, so a restart does not re-hash tens of gigabytes. */
-const STATE_FILE = ".douga-models.json";
+const STATE_FILE = ".preset-models.json";
 
 export type ManifestModel = {
   filename: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,17 @@ export type JobRecord = {
   interrupted?: boolean;
 };
 
+/**
+ * A workflow shipped inside the claim itself (douga-workflow #127). The JSON is
+ * API format; placeholders (`__INPUT_IMAGE__`, `__TRIGGER_WORDS__`, `__SEED__`)
+ * are substituted here before queueing.
+ */
+export type ServerWorkflow = {
+  presetId: string;
+  workflowJson: string;
+  triggerWords: string | null;
+};
+
 /** Job payload handed out by an upstream server's claim endpoint. */
 export type ClaimedJob = {
   jobId: string;
@@ -81,6 +92,9 @@ export type ClaimedJob = {
   sourceImageContentType: string;
   /** Optional per-job overrides; upstreams that don't send these get defaults. */
   params?: RunParams;
-  /** Workflow name to run. Falls back to the active workflow when absent. */
-  workflow?: string;
+  /**
+   * What to run. A string names a local workflow file; an object carries the
+   * workflow itself. Absent (or null) falls back to the active local workflow.
+   */
+  workflow?: string | ServerWorkflow | null;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export type JobRecord = {
 };
 
 /**
- * A workflow shipped inside the claim itself (douga-workflow #127). The JSON is
+ * A workflow shipped inside the claim itself by the upstream server. The JSON is
  * API format; placeholders (`__INPUT_IMAGE__`, `__TRIGGER_WORDS__`, `__SEED__`)
  * are substituted here before queueing.
  */

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -5,7 +5,7 @@ import { COMFY_URL, JOB_TIMEOUT_MS, WORKFLOW_DIR } from "./config";
 import { loadSettings, saveSettings } from "./settings";
 import { applyOverrides, detectSlots, parseApiWorkflow, readNumber } from "./slots";
 import type { ApiWorkflow, Slot, SlotOverrides, WorkflowSlots } from "./slots";
-import type { RunOutput, RunParams } from "./types";
+import type { RunOutput, RunParams, ServerWorkflow } from "./types";
 
 export type LoadedWorkflow = {
   name: string;
@@ -258,6 +258,72 @@ export async function runWorkflow(
 ): Promise<RunOutput[]> {
   const loaded = await loadWorkflow(name);
   const promptId = await queuePrompt(COMFY_URL, applyParams(loaded, params));
+  onQueued?.(promptId);
+
+  const entry = await waitForPrompt(COMFY_URL, promptId, JOB_TIMEOUT_MS);
+
+  const failure = runFailure(entry);
+  if (failure) throw new Error(failure);
+
+  const outputs = collectOutputs(COMFY_URL, entry);
+  if (outputs.length === 0) {
+    throw new Error("run finished but produced no files — does the workflow have a save node?");
+  }
+  return outputs;
+}
+
+/**
+ * Placeholders a server-supplied workflow may carry (douga-workflow #127).
+ * Node ids differ per workflow, so the substitution points are marked in the
+ * JSON itself; this walks every node's inputs and swaps values, never touching
+ * the graph's structure.
+ *
+ * - "__INPUT_IMAGE__"   → the uploaded input image's filename
+ * - "__TRIGGER_WORDS__" → the preset's trigger words (empty when null)
+ * - "__SEED__"          → a random seed (number)
+ */
+function substitutePlaceholders(
+  workflow: ApiWorkflow,
+  imageFilename: string | undefined,
+  triggerWords: string | null,
+): void {
+  const seed = Math.floor(Math.random() * 2 ** 32);
+  const trigger = triggerWords ?? "";
+  for (const node of Object.values(workflow)) {
+    for (const [name, value] of Object.entries(node.inputs)) {
+      if (value === "__INPUT_IMAGE__") {
+        if (imageFilename) node.inputs[name] = imageFilename;
+      } else if (value === "__SEED__") {
+        node.inputs[name] = seed;
+      } else if (typeof value === "string" && value.includes("__TRIGGER_WORDS__")) {
+        // No joining commas or spaces added here; the JSON's author decides.
+        node.inputs[name] = value.replaceAll("__TRIGGER_WORDS__", trigger);
+      }
+    }
+  }
+}
+
+/**
+ * Runs a workflow the server shipped with the job. Same submit/wait/collect
+ * path as {@link runWorkflow}; only where the JSON comes from differs.
+ */
+export async function runServerWorkflow(
+  spec: ServerWorkflow,
+  imageFilename: string | undefined,
+  onQueued?: (promptId: string) => void,
+): Promise<RunOutput[]> {
+  let workflow: ApiWorkflow;
+  try {
+    workflow = parseApiWorkflow(JSON.parse(spec.workflowJson));
+  } catch (err) {
+    throw new Error(
+      `preset workflow is not a valid API-format workflow: ${err instanceof Error ? err.message : err}`,
+      { cause: err },
+    );
+  }
+  substitutePlaceholders(workflow, imageFilename, spec.triggerWords);
+
+  const promptId = await queuePrompt(COMFY_URL, workflow);
   onQueued?.(promptId);
 
   const entry = await waitForPrompt(COMFY_URL, promptId, JOB_TIMEOUT_MS);

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -273,7 +273,7 @@ export async function runWorkflow(
 }
 
 /**
- * Placeholders a server-supplied workflow may carry (douga-workflow #127).
+ * Placeholders a server-supplied workflow may carry.
  * Node ids differ per workflow, so the substitution points are marked in the
  * JSON itself; this walks every node's inputs and swaps values, never touching
  * the graph's structure.


### PR DESCRIPTION
Closes #43

Merging `dev` into `main` is the release, per CONTRIBUTING. **Merge #44 (the
version bump) into `dev` first** — this PR tracks `dev` live, so it will pick
the bump up on its own.

Once this lands on `main`, the Release workflow builds the Windows installers,
signs the updater artifacts and opens a **draft** `v0.3.0` release. Publishing
that draft is the switch: from that moment every installed agent offers the
update — at launch, daily, and from Check for updates in the tray.

## What ships

- Preset model sync and server-supplied workflow execution (#41)
- Node-definition reporting to every upstream (#41/#42) — unblocks the
  upstream workflow editor's node palette

Note: `v0.1.2` and `v0.2.0` are still sitting as unpublished drafts. If 0.3.0
is published, those can stay drafts or be deleted — installed apps only look at
the latest published release.