### PR TITLE
feat(runs): remove the in-app run form

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ upstream server setting
 <img width="774" height="374" alt="image" src="https://github.com/user-attachments/assets/cac74acb-4b12-4d5c-82c5-c5881a9bf2a8" />
 
 
-A desktop app that runs your own ComfyUI workflows, starts and stops ComfyUI
-itself, and can hand the GPU to a job server when you are not using it.
+A desktop app that hands your GPU to a job server: it claims queued jobs, runs
+them through your own ComfyUI workflows, and starts and stops ComfyUI itself.
 
 It sits in the tray. Close the window and it keeps working; the tray menu is
 enough to stop ComfyUI or stop taking new jobs without opening anything.
@@ -23,8 +23,8 @@ enough to stop ComfyUI or stop taking new jobs without opening anything.
   app reads the graph to find the prompts, seed, length and input image
 - **Runs ComfyUI for you** — one button, with the tail of its output when the
   command is wrong
-- **Standalone or attached** — useful on its own; point it at one or more job
-  servers when you want it to serve requests from elsewhere
+- **Standalone or attached** — manages ComfyUI on its own; point it at one or
+  more job servers when you want it to serve requests from elsewhere
 - **English and Japanese**, light and dark, remembered per browser
 
 ## Install
@@ -89,15 +89,13 @@ a row in by hand; reorder and disable them here too. The order is the priority.
 the next while, or a daily window. [When it accepts](#when-it-accepts) has the
 details.
 
-**Generate** runs a workflow by hand: a form on one side, the run history on the
-other. Handy for checking a workflow does what you think before a job server
-starts sending work. The history narrows by state and by where the job came
-from, and flips into a gallery of everything the filtered runs produced.
+**Runs** is the history: every job claimed from a job server, narrowed by state
+and flipped into a gallery of everything the filtered runs produced. *Interrupt*
+asks ComfyUI to abort the run in flight.
 
 A run in flight carries a bar — the steps ComfyUI has done out of the steps it
-expects, and the node it is on — so a slow workflow can be told from a stuck one.
-Jobs claimed from a job server land in the same history, so they get the same
-bar, and the status bar carries the percentage on every page.
+expects, and the node it is on — so a slow workflow can be told from a stuck
+one, and the status bar carries the percentage on every page.
 
 The header switches the theme and the language, and the button beside them opens
 the app's own settings — the same switches the tray menu carries.
@@ -107,11 +105,11 @@ the app's own settings — the same switches the tray menu carries.
 Beside *Start ComfyUI* is a dot with three states, picked the way a chat app
 picks a presence.
 
-| | | Jobs from a job server | Runs you start here | ComfyUI |
-| --- | --- | --- | --- | --- |
-| 🟢 | **Accepting** | yes | yes | left alone |
-| 🟡 | **Not accepting** | no | yes | left alone |
-| 🔴 | **Stopped** | no | no | shut down |
+| | | Jobs from a job server | ComfyUI |
+| --- | --- | --- | --- |
+| 🟢 | **Accepting** | yes | left alone |
+| 🟡 | **Not accepting** | no | left alone |
+| 🔴 | **Stopped** | no | shut down |
 
 *Not accepting* is the one worth knowing about. It stops the queue without
 disconnecting from anything: job servers still see the machine, they just get
@@ -138,10 +136,9 @@ The same three are in the tray, so it can be changed with the window closed.
   overnight. An end before the start crosses midnight, so that window is tonight
   until tomorrow morning rather than an error.
 
-Both only hold jobs back. ComfyUI stays up, runs you start here still go, and
-job servers still see the machine — they simply get nothing out of it until the
-hold is over. The header says which of the two is holding it and the status bar
-says how much is left.
+Both only hold jobs back. ComfyUI stays up and job servers still see the
+machine — they simply get nothing out of it until the hold is over. The header
+says which of the two is holding it and the status bar says how much is left.
 
 A hold is stored with its end time rather than counted down in memory, so
 restarting the app in the middle of one does not start claiming early.
@@ -199,9 +196,9 @@ inputs without being told:
 | `length`    | a node with a numeric `length` input (frame count on video workflows) |
 | `frameRate` | a node with a numeric `frame_rate` input                              |
 
-The Workflows page shows which of these were found, so a workflow that needs help
-is obvious before you run it. Anything not found is simply not offered — a
-workflow with no `LoadImage` gets no image field.
+The Workflows page shows which of these were found, so a workflow that needs
+help is obvious before a job server sends work. A parameter whose slot was not
+found is simply ignored — a workflow with no `LoadImage` takes no input image.
 
 *Check* on a workflow's row goes further: it asks the running ComfyUI — via
 `/object_info` — whether every node type in the file exists there, and whether
@@ -231,10 +228,10 @@ reported in the UI rather than silently ignored.
 
 ## Attaching a job server
 
-Left alone, the app runs standalone. Add a server on the Servers page and it
-also polls for queued jobs, runs them through the active workflow and uploads
-the result — which is the point of the tray: the machine keeps serving with
-nothing on screen.
+Left alone, the app only manages ComfyUI. Add a server on the Servers page and
+it polls for queued jobs, runs them through the active workflow and uploads the
+result — which is the point of the tray: the machine keeps serving with nothing
+on screen.
 
 Each row has a *Test* button. It sends one heartbeat there and then, so a wrong
 secret answers `HTTP 401` immediately instead of looking like an unreachable host

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -129,8 +129,7 @@ async function processJob(server: UpstreamServer, claimed: ClaimedJob) {
 
   // A transient failure — a network blip, ComfyUI mid-restart — gets retried
   // on this machine before the job server hears anything: the job is claimed
-  // and would not be handed out again anyway. Only claimed jobs retry; a run
-  // from the UI has someone watching it, who would not expect a quiet rerun.
+  // and would not be handed out again anyway.
   const tries = 1 + JOB_RETRIES;
 
   for (let attempt = 1; ; attempt++) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export type RunParams = {
   fps?: number;
 };
 
+/** "ui" no longer occurs in new jobs; it survives in histories written by older versions. */
 export type JobSource = "ui" | "upstream";
 
 export type JobState = "running" | "succeeded" | "failed";
@@ -55,7 +56,7 @@ export type JobState = "running" | "succeeded" | "failed";
 export type JobRecord = {
   id: string;
   source: JobSource;
-  /** Upstream server name for claimed jobs; undefined for UI test runs. */
+  /** Upstream server the job was claimed from; absent in older histories. */
   origin?: string;
   workflow: string;
   state: JobState;

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -42,7 +42,6 @@ type RunOutput = {
 
 type JobRecord = {
   id: string;
-  source: "ui" | "upstream";
   origin?: string;
   workflow: string;
   state: "running" | "succeeded" | "failed";
@@ -123,7 +122,7 @@ type State = {
 };
 
 const POLL_MS = 2000;
-const PAGES = ["workflows", "comfyui", "servers", "accepting", "generate"] as const;
+const PAGES = ["workflows", "comfyui", "servers", "accepting", "runs"] as const;
 type Page = (typeof PAGES)[number];
 
 function el<T extends HTMLElement>(id: string): T {
@@ -146,10 +145,7 @@ const nodes = {
   linkCode: el<HTMLInputElement>("link-code"),
   linkNote: el("link-note"),
   jobs: el("jobs"),
-  form: el<HTMLFormElement>("run-form"),
-  select: el<HTMLSelectElement>("run-workflow"),
-  submit: el<HTMLButtonElement>("run-submit"),
-  note: el("run-note"),
+  jobsNote: el("jobs-note"),
   reload: el<HTMLButtonElement>("reload"),
   interrupt: el<HTMLButtonElement>("interrupt"),
   uploadForm: el<HTMLFormElement>("upload-form"),
@@ -316,8 +312,8 @@ function setNote(target: HTMLElement, text: string, isError = false): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Workflows is the landing tab; running a workflow by hand is the sideline.
- * Any hash naming no tab lands there too — the old `#/settings` included.
+ * Workflows is the landing tab. Any hash naming no tab lands there too — the
+ * old `#/settings` and `#/generate` included.
  */
 function currentPage(): Page {
   const hash = location.hash.replace(/^#\/?/, "");
@@ -765,10 +761,9 @@ function progressBar(job: JobRecord, progress: State["progress"]): string {
 
 function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress"]): string {
   const tone = job.state === "running" ? "run" : job.state === "succeeded" ? "ok" : "bad";
-  const origin =
-    job.source === "upstream"
-      ? ` · ${esc(job.origin ?? t("jobs.upstream"))}`
-      : ` · ${t("jobs.ui")}`;
+  // Which job server the job was claimed from. Rows written by old versions'
+  // in-app run form have no origin, so they simply say nothing.
+  const origin = job.origin ? ` · ${esc(job.origin)}` : "";
   const timing =
     job.state === "running"
       ? `<span data-started="${job.startedAt}">${formatDuration(Date.now() - job.startedAt)}</span>`
@@ -798,11 +793,9 @@ function jobEntry(job: JobRecord, withDelete: boolean, progress: State["progress
 
 // Page-local: the history itself is what it is, only its reading is chosen.
 type JobStateFilter = "all" | JobRecord["state"];
-type JobSourceFilter = "all" | JobRecord["source"];
 type JobsView = "list" | "gallery";
 
 let jobStateFilter: JobStateFilter = "all";
-let jobSourceFilter: JobSourceFilter = "all";
 let jobsView: JobsView = "list";
 
 /**
@@ -835,11 +828,7 @@ function galleryHtml(jobs: JobRecord[]): string {
 }
 
 function renderJobs(state: State): void {
-  const jobs = state.jobs.filter(
-    (job) =>
-      (jobStateFilter === "all" || job.state === jobStateFilter) &&
-      (jobSourceFilter === "all" || job.source === jobSourceFilter),
-  );
+  const jobs = state.jobs.filter((job) => jobStateFilter === "all" || job.state === jobStateFilter);
 
   if (jobsView === "gallery") {
     renderIfChanged(nodes.jobs, "jobs", galleryHtml(jobs));
@@ -1170,58 +1159,6 @@ async function setNotify(on: boolean): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Run form
-// ---------------------------------------------------------------------------
-
-let selectKey = "";
-
-function syncForm(state: State): void {
-  const valid = state.workflows.filter((summary) => summary.valid).map((summary) => summary.name);
-  const key = valid.join(" ");
-
-  // Assigning a value the select has no option for silently blanks it, which
-  // would then read back as "no workflow" — so only ever pick from `valid`.
-  const pick = (...candidates: (string | null)[]): string =>
-    candidates.find((name): name is string => name !== null && valid.includes(name)) ??
-    valid[0] ??
-    "";
-
-  if (key !== selectKey) {
-    selectKey = key;
-    const previous = nodes.select.value;
-    nodes.select.innerHTML = valid
-      .map((name) => `<option value="${esc(name)}">${esc(name)}</option>`)
-      .join("");
-    nodes.select.value = pick(previous, state.activeWorkflow);
-  } else if (!valid.includes(nodes.select.value)) {
-    nodes.select.value = pick(state.activeWorkflow);
-  }
-
-  const paused = state.mode === "paused";
-  nodes.submit.disabled = valid.length === 0 || paused;
-  nodes.submit.title = paused ? t("run.paused") : "";
-
-  const selected = state.workflows.find((summary) => summary.name === nodes.select.value);
-  const slots = selected?.slots;
-
-  for (const field of document.querySelectorAll<HTMLElement>("[data-slot]")) {
-    const slotKey = field.dataset["slot"];
-    if (!slotKey) continue;
-    const present = !slots
-      ? false
-      : slotKey === "seed"
-        ? slots.seed.length > 0
-        : Boolean(slots[slotKey as keyof WorkflowSlots]);
-
-    field.classList.toggle("disabled", !present);
-    // Disabled controls are left out of FormData, which is what we want: a
-    // parameter with no slot must not be sent at all.
-    const input = field.querySelector<HTMLInputElement | HTMLTextAreaElement>("input, textarea");
-    if (input) input.disabled = !present;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Polling
 // ---------------------------------------------------------------------------
 
@@ -1241,7 +1178,6 @@ function render(state: State): void {
   syncAccepting(state);
   syncDesktop(state);
   syncNotify(state);
-  syncForm(state);
 }
 
 async function poll(): Promise<void> {
@@ -1339,7 +1275,7 @@ onLangChange(() => {
   // Notes report something that has already happened, so they are cleared
   // rather than translated after the fact.
   for (const note of [
-    nodes.note,
+    nodes.jobsNote,
     nodes.uploadNote,
     nodes.settingsNote,
     nodes.serversNote,
@@ -1359,39 +1295,8 @@ onLangChange(() => {
 // Wiring
 // ---------------------------------------------------------------------------
 
-nodes.form.addEventListener("submit", async (event) => {
-  event.preventDefault();
-  nodes.submit.disabled = true;
-  setNote(nodes.note, t("run.queueing"));
-
-  try {
-    const res = await fetch("/api/run", {
-      method: "POST",
-      headers: authHeaders(),
-      body: new FormData(nodes.form),
-    });
-    const body = (await res.json()) as { jobId?: string; error?: string };
-    if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
-    setNote(nodes.note, t("run.queued"));
-  } catch (err) {
-    setNote(nodes.note, err instanceof Error ? err.message : String(err), true);
-  } finally {
-    nodes.submit.disabled = false;
-    void poll();
-  }
-});
-
-// The selector doubles as the active workflow, so upstream jobs follow it too.
-nodes.select.addEventListener("change", async () => {
-  const name = nodes.select.value;
-  if (!name) return;
-  await post("/api/workflows/active", { name });
-  void poll();
-});
-
 nodes.reload.addEventListener("click", async () => {
   await post("/api/workflows/reload");
-  selectKey = "";
   lastHtml.clear();
   setNote(nodes.uploadNote, t("upload.reloaded"));
   void poll();
@@ -1400,8 +1305,8 @@ nodes.reload.addEventListener("click", async () => {
 nodes.interrupt.addEventListener("click", async () => {
   const result = await post("/api/interrupt");
   setNote(
-    nodes.note,
-    result.ok ? t("run.interruptSent") : (result.error ?? t("run.interruptFailed")),
+    nodes.jobsNote,
+    result.ok ? t("jobs.interruptSent") : (result.error ?? t("jobs.interruptFailed")),
     !result.ok,
   );
   void poll();
@@ -1457,7 +1362,6 @@ nodes.workflows.addEventListener("click", async (event) => {
   if (remove && confirm(t("workflows.deleteConfirm", { name: remove }))) {
     const result = await post("/api/workflows/delete", { name: remove });
     if (!result.ok) setNote(nodes.uploadNote, result.error ?? t("workflows.deleteFailed"), true);
-    selectKey = "";
     lastHtml.delete("workflows");
     void poll();
   }
@@ -1588,7 +1492,6 @@ nodes.jobs.addEventListener("click", async (event) => {
 function syncJobFilterButtons(): void {
   const groups: [attribute: string, current: string][] = [
     ["data-job-state", jobStateFilter],
-    ["data-job-source", jobSourceFilter],
     ["data-job-view", jobsView],
   ];
   for (const [attribute, current] of groups) {
@@ -1598,7 +1501,7 @@ function syncJobFilterButtons(): void {
   }
 }
 
-/** The three groups differ only in which variable a click sets. */
+/** The two groups differ only in which variable a click sets. */
 function wireJobFilter(id: string, attribute: string, apply: (value: string) => void): void {
   el(id).addEventListener("click", (event) => {
     const value = (event.target as HTMLElement)
@@ -1613,9 +1516,6 @@ function wireJobFilter(id: string, attribute: string, apply: (value: string) => 
 
 wireJobFilter("jobs-state", "data-job-state", (value) => {
   jobStateFilter = value as JobStateFilter;
-});
-wireJobFilter("jobs-source", "data-job-source", (value) => {
-  jobSourceFilter = value as JobSourceFilter;
 });
 wireJobFilter("jobs-view", "data-job-view", (value) => {
   jobsView = value as JobsView;

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -39,13 +39,13 @@ const STRINGS = {
   "mode.label": { en: "Generation", ja: "生成" },
   "mode.accepting": { en: "Accepting", ja: "受付中" },
   "mode.acceptingNote": {
-    en: "Jobs from your job servers, and runs started here.",
-    ja: "ジョブサーバーからの仕事も、ここからの実行も動きます。",
+    en: "Jobs from your job servers run on this machine.",
+    ja: "ジョブサーバーからの仕事を実行します。",
   },
   "mode.local": { en: "Not accepting", ja: "受付停止" },
   "mode.localNote": {
-    en: "Job servers get nothing. ComfyUI stays up for your own runs.",
-    ja: "ジョブサーバーからは受け取りません。ComfyUI はそのまま、自分の実行は動きます。",
+    en: "Job servers get nothing. ComfyUI stays up for your own use.",
+    ja: "ジョブサーバーからは受け取りません。ComfyUI はそのまま使えます。",
   },
   "mode.paused": { en: "Stopped", ja: "停止" },
   "mode.pausedNote": {
@@ -66,8 +66,8 @@ const STRINGS = {
   // When jobs are accepted, on top of the mode -------------------------------
   "accept.title": { en: "Accepting jobs", ja: "ジョブの受付" },
   "accept.help": {
-    en: "When job servers get work out of this machine. Runs you start here, and ComfyUI itself, are not affected.",
-    ja: "ジョブサーバーからの仕事をいつ受けるかの設定です。ここから始める実行と ComfyUI 自体には影響しません。",
+    en: "When job servers get work out of this machine. ComfyUI itself is not affected.",
+    ja: "ジョブサーバーからの仕事をいつ受けるかの設定です。ComfyUI 自体には影響しません。",
   },
   "accept.pauseFor": { en: "Hold off for", ja: "一時停止" },
   "accept.pause15": { en: "15 min", ja: "15分" },
@@ -95,12 +95,12 @@ const STRINGS = {
   "accept.paused": { en: "on hold {minutes}m", ja: "停止中 あと{minutes}分" },
   "accept.outside": { en: "outside the window", ja: "時間帯外" },
   "accept.gatePaused": {
-    en: "Jobs are on hold for another {minutes} min. Runs started here still go.",
-    ja: "あと {minutes} 分はジョブを受けません。ここからの実行は動きます。",
+    en: "Jobs are on hold for another {minutes} min.",
+    ja: "あと {minutes} 分はジョブを受けません。",
   },
   "accept.gateSchedule": {
-    en: "Outside {from}–{to}, so nothing is claimed. Runs started here still go.",
-    ja: "{from}〜{to} の外なのでジョブは受けません。ここからの実行は動きます。",
+    en: "Outside {from}–{to}, so nothing is claimed.",
+    ja: "{from}〜{to} の外なのでジョブは受けません。",
   },
 
   // The desktop menu, mirrored by the tray -----------------------------------
@@ -154,7 +154,7 @@ const STRINGS = {
   "nav.comfyui": { en: "ComfyUI", ja: "ComfyUI" },
   "nav.servers": { en: "Servers", ja: "サーバー" },
   "nav.accepting": { en: "Accepting", ja: "ジョブ受付" },
-  "nav.generate": { en: "Generate", ja: "生成" },
+  "nav.runs": { en: "Runs", ja: "実行履歴" },
 
   // Status chips ------------------------------------------------------------
   "vitals.comfy": { en: "ComfyUI", ja: "ComfyUI" },
@@ -177,45 +177,23 @@ const STRINGS = {
   "comfy.busy": { en: "busy", ja: "実行中" },
   "comfy.unavailable": { en: "unavailable", ja: "停止中" },
 
-  // Run ---------------------------------------------------------------------
-  "run.title": { en: "Run", ja: "実行" },
-  "run.interrupt": { en: "Interrupt", ja: "中断" },
-  "run.workflow": { en: "Workflow", ja: "ワークフロー" },
-  "run.positive": { en: "Positive prompt", ja: "ポジティブプロンプト" },
-  "run.negative": { en: "Negative prompt", ja: "ネガティブプロンプト" },
-  "run.promptPlaceholder": {
-    en: "keep the workflow's own prompt",
-    ja: "ワークフローの内容をそのまま使う",
-  },
-  "run.seed": { en: "Seed", ja: "シード" },
-  "run.random": { en: "random", ja: "ランダム" },
-  "run.seconds": { en: "Seconds", ja: "秒数" },
-  "run.fps": { en: "FPS", ja: "FPS" },
-  "run.default": { en: "default", ja: "既定値" },
-  "run.image": { en: "Input image", ja: "入力画像" },
-  "run.submit": { en: "Run", ja: "実行" },
-  "run.paused": { en: "new work is paused", ja: "新規の受付を停止中です" },
-  "run.queueing": { en: "queueing…", ja: "送信中…" },
-  "run.queued": { en: "queued — it appears in Runs", ja: "送信しました。実行履歴に出ます" },
-  "run.interruptSent": { en: "interrupt sent", ja: "中断を送信しました" },
-  "run.interruptFailed": { en: "interrupt failed", ja: "中断できませんでした" },
-
   // Runs --------------------------------------------------------------------
   "jobs.title": { en: "Runs", ja: "実行履歴" },
+  "jobs.interrupt": { en: "Interrupt", ja: "中断" },
+  "jobs.interruptSent": { en: "interrupt sent", ja: "中断を送信しました" },
+  "jobs.interruptFailed": { en: "interrupt failed", ja: "中断できませんでした" },
   "jobs.clear": { en: "Clear finished", ja: "完了分を削除" },
   "jobs.clearConfirm": {
     en: "Clear every finished job from the history?",
     ja: "完了したジョブを履歴からすべて削除しますか？",
   },
   "jobs.empty": {
-    en: "Nothing has run yet. Fill in the form and press Run.",
-    ja: "まだ何も実行していません。フォームを入力して実行してください。",
+    en: "Nothing has run yet. Jobs claimed from your job servers appear here.",
+    ja: "まだ何も実行していません。ジョブサーバーから受けた仕事がここに出ます。",
   },
   "jobs.running": { en: "running", ja: "実行中" },
   "jobs.succeeded": { en: "succeeded", ja: "成功" },
   "jobs.failed": { en: "failed", ja: "失敗" },
-  "jobs.ui": { en: "UI", ja: "UI" },
-  "jobs.upstream": { en: "upstream", ja: "上流" },
   "jobs.prompt": { en: "prompt {id}", ja: "prompt {id}" },
   "jobs.progress": {
     en: "{percent}% · step {value}/{max}",
@@ -225,7 +203,6 @@ const STRINGS = {
   "jobs.attempt": { en: "attempt {count}", ja: "試行 {count} 回目" },
   "jobs.all": { en: "All", ja: "すべて" },
   "jobs.filterState": { en: "State", ja: "状態" },
-  "jobs.filterSource": { en: "Source", ja: "発生元" },
   "jobs.filterView": { en: "View", ja: "表示" },
   "jobs.listView": { en: "List", ja: "リスト" },
   "jobs.galleryView": { en: "Gallery", ja: "ギャラリー" },
@@ -370,8 +347,8 @@ const STRINGS = {
   },
   "servers.linkFailed": { en: "linking failed", ja: "リンクできませんでした" },
   "servers.empty": {
-    en: "No upstream servers. This machine runs whatever you queue here and nothing else.",
-    ja: "上流サーバーはありません。このマシンはここで入れた分だけを実行します。",
+    en: "No upstream servers. Nothing runs on this machine until one is added.",
+    ja: "上流サーバーはありません。追加するまでこのマシンでは何も実行されません。",
   },
   "servers.save": { en: "Save servers", ja: "サーバー設定を保存" },
   "servers.revert": { en: "Revert", ja: "元に戻す" },
@@ -407,9 +384,6 @@ const STRINGS = {
   // Durations ---------------------------------------------------------------
   "time.seconds": { en: "{seconds}s", ja: "{seconds}秒" },
   "time.minutes": { en: "{minutes}m {seconds}s", ja: "{minutes}分{seconds}秒" },
-
-  /** Appended by CSS to a field the chosen workflow has no slot for. */
-  "field.unused": { en: "unused", ja: "未使用" },
 } satisfies Record<string, Entry>;
 
 export type Key = keyof typeof STRINGS;
@@ -490,10 +464,6 @@ export function onLangChange(listener: () => void): void {
 export function setLang(next: Lang): void {
   current = next;
   document.documentElement.lang = next;
-
-  // The one label CSS writes rather than the DOM, because it is generated
-  // content. Set here so it needs no rule of its own per language.
-  document.documentElement.style.setProperty("--label-unused", `" · ${t("field.unused")}"`);
 
   try {
     localStorage.setItem(STORAGE_KEY, next);

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -256,173 +256,91 @@
         <a class="nav-item" href="#/accepting" data-page-link="accepting" data-i18n="nav.accepting"
           >Accepting</a
         >
-        <a class="nav-item" href="#/generate" data-page-link="generate" data-i18n="nav.generate"
-          >Generate</a
-        >
+        <a class="nav-item" href="#/runs" data-page-link="runs" data-i18n="nav.runs">Runs</a>
       </nav>
 
       <main class="content">
-        <section class="page workbench" data-page="generate" hidden>
-          <div class="column">
-            <section class="panel">
-              <div class="panel-head">
-                <h2 data-i18n="run.title">Run</h2>
-                <button type="button" class="ghost" id="interrupt" data-i18n="run.interrupt">
-                  Interrupt
+        <!-- History only: every run here was claimed from a job server, and
+             Interrupt asks ComfyUI to abort whatever is in flight. -->
+        <section class="page" data-page="runs" hidden>
+          <section class="panel">
+            <div class="panel-head">
+              <h2 data-i18n="jobs.title">Runs</h2>
+              <span class="spacer"></span>
+              <button type="button" class="ghost" id="interrupt" data-i18n="jobs.interrupt">
+                Interrupt
+              </button>
+              <button type="button" class="ghost" id="jobs-clear" data-i18n="jobs.clear">
+                Clear finished
+              </button>
+            </div>
+
+            <!-- Narrowing and reshaping only — the history itself is what it
+                 is. The choices live in the page, not on the server. -->
+            <div class="filters">
+              <div
+                class="segmented text"
+                id="jobs-state"
+                role="group"
+                data-i18n-label="jobs.filterState"
+              >
+                <button type="button" data-job-state="all" data-i18n="jobs.all">All</button>
+                <button type="button" data-job-state="running" data-i18n="jobs.running">
+                  running
+                </button>
+                <button type="button" data-job-state="succeeded" data-i18n="jobs.succeeded">
+                  succeeded
+                </button>
+                <button type="button" data-job-state="failed" data-i18n="jobs.failed">
+                  failed
                 </button>
               </div>
-
-              <form id="run-form">
-                <label class="field">
-                  <span data-i18n="run.workflow">Workflow</span>
-                  <select id="run-workflow" name="workflow"></select>
-                </label>
-
-                <label class="field" data-slot="positive">
-                  <span data-i18n="run.positive">Positive prompt</span>
-                  <textarea
-                    name="positive"
-                    rows="3"
-                    data-i18n-placeholder="run.promptPlaceholder"
-                  ></textarea>
-                </label>
-
-                <label class="field" data-slot="negative">
-                  <span data-i18n="run.negative">Negative prompt</span>
-                  <textarea
-                    name="negative"
-                    rows="2"
-                    data-i18n-placeholder="run.promptPlaceholder"
-                  ></textarea>
-                </label>
-
-                <div class="row">
-                  <label class="field" data-slot="seed">
-                    <span data-i18n="run.seed">Seed</span>
-                    <input type="number" name="seed" data-i18n-placeholder="run.random" />
-                  </label>
-                  <label class="field" data-slot="length">
-                    <span data-i18n="run.seconds">Seconds</span>
-                    <input
-                      type="number"
-                      name="seconds"
-                      step="0.1"
-                      data-i18n-placeholder="run.default"
-                    />
-                  </label>
-                  <label class="field" data-slot="frameRate">
-                    <span data-i18n="run.fps">FPS</span>
-                    <input type="number" name="fps" data-i18n-placeholder="run.default" />
-                  </label>
-                </div>
-
-                <label class="field" data-slot="image">
-                  <span data-i18n="run.image">Input image</span>
-                  <input type="file" name="image" accept="image/*" />
-                </label>
-
-                <!-- Pinned to the foot of the panel. It is pressed over and over,
-                     so it must not move when the form above it changes. -->
-                <div class="actions">
-                  <button type="submit" id="run-submit" data-i18n="run.submit">Run</button>
-                  <p class="muted" id="run-note"></p>
-                </div>
-              </form>
-            </section>
-          </div>
-
-          <div class="column">
-            <section class="panel">
-              <div class="panel-head">
-                <h2 data-i18n="jobs.title">Runs</h2>
-                <button type="button" class="ghost" id="jobs-clear" data-i18n="jobs.clear">
-                  Clear finished
+              <div class="segmented" id="jobs-view" role="group" data-i18n-label="jobs.filterView">
+                <button
+                  type="button"
+                  data-job-view="list"
+                  data-i18n-title="jobs.listView"
+                  aria-pressed="true"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M4 6h16M4 12h16M4 18h16" />
+                  </svg>
+                  <span class="sr-only" data-i18n="jobs.listView">List</span>
+                </button>
+                <button
+                  type="button"
+                  data-job-view="gallery"
+                  data-i18n-title="jobs.galleryView"
+                  aria-pressed="false"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    aria-hidden="true"
+                  >
+                    <rect x="4" y="4" width="7" height="7" rx="1" />
+                    <rect x="13" y="4" width="7" height="7" rx="1" />
+                    <rect x="4" y="13" width="7" height="7" rx="1" />
+                    <rect x="13" y="13" width="7" height="7" rx="1" />
+                  </svg>
+                  <span class="sr-only" data-i18n="jobs.galleryView">Gallery</span>
                 </button>
               </div>
+            </div>
+            <p class="muted" id="jobs-note"></p>
 
-              <!-- Narrowing and reshaping only — the history itself is what it
-                   is. The choices live in the page, not on the server. -->
-              <div class="filters">
-                <div
-                  class="segmented text"
-                  id="jobs-state"
-                  role="group"
-                  data-i18n-label="jobs.filterState"
-                >
-                  <button type="button" data-job-state="all" data-i18n="jobs.all">All</button>
-                  <button type="button" data-job-state="running" data-i18n="jobs.running">
-                    running
-                  </button>
-                  <button type="button" data-job-state="succeeded" data-i18n="jobs.succeeded">
-                    succeeded
-                  </button>
-                  <button type="button" data-job-state="failed" data-i18n="jobs.failed">
-                    failed
-                  </button>
-                </div>
-                <div
-                  class="segmented text"
-                  id="jobs-source"
-                  role="group"
-                  data-i18n-label="jobs.filterSource"
-                >
-                  <button type="button" data-job-source="all" data-i18n="jobs.all">All</button>
-                  <button type="button" data-job-source="ui" data-i18n="jobs.ui">UI</button>
-                  <button type="button" data-job-source="upstream" data-i18n="jobs.upstream">
-                    upstream
-                  </button>
-                </div>
-                <div
-                  class="segmented"
-                  id="jobs-view"
-                  role="group"
-                  data-i18n-label="jobs.filterView"
-                >
-                  <button
-                    type="button"
-                    data-job-view="list"
-                    data-i18n-title="jobs.listView"
-                    aria-pressed="true"
-                  >
-                    <svg
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      aria-hidden="true"
-                    >
-                      <path d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                    <span class="sr-only" data-i18n="jobs.listView">List</span>
-                  </button>
-                  <button
-                    type="button"
-                    data-job-view="gallery"
-                    data-i18n-title="jobs.galleryView"
-                    aria-pressed="false"
-                  >
-                    <svg
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      aria-hidden="true"
-                    >
-                      <rect x="4" y="4" width="7" height="7" rx="1" />
-                      <rect x="13" y="4" width="7" height="7" rx="1" />
-                      <rect x="4" y="13" width="7" height="7" rx="1" />
-                      <rect x="13" y="13" width="7" height="7" rx="1" />
-                    </svg>
-                    <span class="sr-only" data-i18n="jobs.galleryView">Gallery</span>
-                  </button>
-                </div>
-              </div>
-
-              <div id="jobs"></div>
-            </section>
-          </div>
+            <div id="jobs"></div>
+          </section>
         </section>
 
         <section class="page" data-page="workflows">

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1,18 +1,10 @@
 import { MAX_PAUSE_MINUTES, acceptState, isTimeOfDay, pauseUntil } from "../accepting";
 import { agentSnapshot, applyUpstreamChange } from "../agent";
-import { interrupt, uploadImage, viewUrl } from "../comfy";
+import { interrupt, viewUrl } from "../comfy";
 import { comfyProcessState, startComfy, stopComfy } from "../comfy-process";
 import { COMFY_URL, UI_HOSTNAME, UI_PORT, UI_TOKEN, WORKFLOW_DIR } from "../config";
 import { listEvents } from "../events";
-import {
-  clearFinishedJobs,
-  completeJob,
-  failJob,
-  listJobs,
-  markQueued,
-  removeJob,
-  startJob,
-} from "../jobs";
+import { clearFinishedJobs, listJobs, removeJob } from "../jobs";
 import { outputsSnapshot, rescanOutputs, trimOutputs } from "../outputs";
 import { latestProgress } from "../progress";
 import {
@@ -30,8 +22,6 @@ import {
   clearWorkflowCache,
   deleteWorkflowFile,
   listWorkflows,
-  loadWorkflow,
-  runWorkflow,
   saveWorkflowFile,
   setActiveWorkflow,
 } from "../workflow";
@@ -40,7 +30,6 @@ import { checkWorkflow } from "../validate";
 import { authorise } from "./guard";
 import index from "./index.html";
 import type { AcceptSchedule, RunMode, UpstreamConfig } from "../settings";
-import type { RunParams } from "../types";
 
 function message(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -491,66 +480,8 @@ function handleJobsClear(): Response {
 }
 
 // ---------------------------------------------------------------------------
-// Running
+// Outputs
 // ---------------------------------------------------------------------------
-
-/**
- * Start a run and return immediately with the job id. Generation takes minutes,
- * far longer than a request should stay open, so progress is read back through
- * `/api/state`.
- */
-async function handleRun(req: Request): Promise<Response> {
-  try {
-    if ((await loadSettings()).mode === "paused") return fail("new work is paused", 409);
-
-    const form = await req.formData();
-
-    const text = (key: string): string | undefined => {
-      const value = form.get(key);
-      return typeof value === "string" && value.trim() !== "" ? value : undefined;
-    };
-    const number = (key: string): number | undefined => {
-      const raw = text(key);
-      if (raw === undefined) return undefined;
-      const parsed = Number(raw);
-      return Number.isFinite(parsed) ? parsed : undefined;
-    };
-
-    const name = text("workflow") ?? (await activeWorkflowName());
-    if (!name) return fail("no workflow selected");
-
-    // Parse before starting anything, so a broken file answers the request with
-    // the reason instead of logging a job that was doomed from the start.
-    await loadWorkflow(name);
-
-    const params: RunParams = {
-      positivePrompt: text("positive"),
-      negativePrompt: text("negative"),
-      seed: number("seed"),
-      seconds: number("seconds"),
-      fps: number("fps"),
-    };
-
-    const image = form.get("image");
-    if (image instanceof File && image.size > 0) {
-      params.imageFilename = await uploadImage(
-        COMFY_URL,
-        image.name || "input.png",
-        image.type || "image/png",
-        new Uint8Array(await image.arrayBuffer()),
-      );
-    }
-
-    const job = startJob({ id: crypto.randomUUID(), source: "ui", workflow: name });
-    void runWorkflow(name, params, (promptId) => markQueued(job, promptId))
-      .then((outputs) => completeJob(job, outputs))
-      .catch((err) => failJob(job, message(err)));
-
-    return Response.json({ jobId: job.id });
-  } catch (err) {
-    return fail(err);
-  }
-}
 
 /**
  * Serve ComfyUI outputs through this process so the UI works when ComfyUI is
@@ -631,7 +562,6 @@ export function startUi() {
       "/api/jobs/delete": { POST: guarded(handleJobDelete) },
       "/api/jobs/clear": { POST: guarded(handleJobsClear) },
 
-      "/api/run": { POST: guarded(handleRun) },
       "/api/interrupt": { POST: guarded(handleInterrupt) },
       "/api/output": { GET: guarded(handleOutput) },
     },

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -74,10 +74,6 @@
   --control: 2.25rem;
   --control-sm: 1.875rem;
 
-  /* Generated content, so it cannot come from the DOM. The value here is what
-     shows until the i18n module replaces it with the chosen language. */
-  --label-unused: " · unused";
-
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-in: cubic-bezier(0.7, 0, 0.84, 0);
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
@@ -581,28 +577,6 @@ button.ghost.square svg {
   display: none;
 }
 
-/* --------------------------------------------------------------------------
-   Workbench — controls on one side, what the machine is doing on the other
-   -------------------------------------------------------------------------- */
-
-.page.workbench {
-  max-width: 76rem;
-}
-
-@media (min-width: 62rem) {
-  .page.workbench {
-    grid-template-columns: minmax(0, 21rem) minmax(0, 1fr);
-    align-items: start;
-  }
-}
-
-.column {
-  display: grid;
-  gap: var(--space-xs);
-  align-content: start;
-  min-width: 0;
-}
-
 .panel {
   min-width: 0;
   padding: var(--space-sm);
@@ -635,15 +609,6 @@ button.ghost.square svg {
   font-size: var(--text-2xs);
   font-weight: 500;
   color: var(--muted-foreground);
-}
-
-.field.disabled {
-  opacity: 0.5;
-}
-
-.field.disabled > span::after {
-  content: var(--label-unused);
-  font-weight: 400;
 }
 
 input,


### PR DESCRIPTION
Closes #46

## 概要

Generate ページの手動実行フォーム（アプリ内で生成を始める機能）を削除します。生成はジョブサーバーから受けたジョブだけになり、UI からは実行できません。ジョブサーバー経由の実行（agent）には手を入れていません。

## 変更内容

- `/api/run` エンドポイントと Run フォーム一式（`syncForm`・スロット連動の入力欄・`run.*` の文言）を削除
- Generate ページを実行履歴だけの **Runs** ページに変更（ハッシュは `#/runs`、旧 `#/generate` は Workflows に落ちます）
- 発生元フィルタ（UI / upstream）を削除。今後はすべて upstream のため、履歴の行はジョブサーバー名だけを表示します（旧バージョンの UI 実行の行は名前なしで表示）
- **Interrupt** は実行中ジョブの中断用として Runs パネルの見出しに移動（`/api/interrupt` は維持）
- フォームでしか使っていなかった CSS（`workbench` 2 カラム・`field.disabled`・`--label-unused`）を削除
- 「ここからの実行は動きます」系の文言と README（モード表・Generate 節など）を実態に合わせて更新

## 補足

- リリース #45 のマージで リモートの `dev` が branch 自動削除により消えていたため、`origin/main`（0.3.0）から `dev` を作り直しています
- 動作確認: `bun run check` / `bun run check-types` 通過、サーバーを起動して `/api/state` 200・`/api/run` 404・ページ配信 200 を確認済み